### PR TITLE
Fix #3: IImage関連インターフェースの移行と拡張

### DIFF
--- a/Baketa.Core/Abstractions/Imaging/IAdvancedImage.cs
+++ b/Baketa.Core/Abstractions/Imaging/IAdvancedImage.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Imaging
+{
+    /// <summary>
+    /// 高度な画像処理機能を提供するインターフェース
+    /// </summary>
+    public interface IAdvancedImage : IImage
+    {
+        /// <summary>
+        /// 画像にフィルターを適用します。
+        /// </summary>
+        /// <param name="filterType">適用するフィルタータイプ</param>
+        /// <returns>フィルターが適用された新しい画像インスタンス</returns>
+        Task<IImage> ApplyFilterAsync(ImageFilterType filterType);
+        
+        /// <summary>
+        /// 2つの画像の類似度を計算します。
+        /// </summary>
+        /// <param name="other">比較対象の画像</param>
+        /// <returns>0.0〜1.0の類似度（1.0が完全一致）</returns>
+        Task<float> CalculateSimilarityAsync(IImage other);
+        
+        /// <summary>
+        /// 画像の特定領域を切り出します。
+        /// </summary>
+        /// <param name="x">切り出し開始X座標</param>
+        /// <param name="y">切り出し開始Y座標</param>
+        /// <param name="width">切り出し幅</param>
+        /// <param name="height">切り出し高さ</param>
+        /// <returns>切り出された新しい画像インスタンス</returns>
+        Task<IImage> CropAsync(int x, int y, int width, int height);
+        
+        /// <summary>
+        /// 画像の回転を行います。
+        /// </summary>
+        /// <param name="degrees">回転角度（度数法）</param>
+        /// <returns>回転された新しい画像インスタンス</returns>
+        Task<IImage> RotateAsync(float degrees);
+    }
+    
+    /// <summary>
+    /// 画像フィルタータイプ
+    /// </summary>
+    public enum ImageFilterType
+    {
+        /// <summary>グレースケール</summary>
+        Grayscale,
+        
+        /// <summary>ぼかし</summary>
+        Blur,
+        
+        /// <summary>シャープ化</summary>
+        Sharpen,
+        
+        /// <summary>エッジ検出</summary>
+        EdgeDetection,
+        
+        /// <summary>コントラスト強調</summary>
+        ContrastEnhancement,
+        
+        /// <summary>二値化</summary>
+        Binarize,
+        
+        /// <summary>ガンマ補正</summary>
+        GammaCorrection
+    }
+}

--- a/Baketa.Core/Abstractions/Imaging/IImage.cs
+++ b/Baketa.Core/Abstractions/Imaging/IImage.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Imaging
+{
+    /// <summary>
+    /// 標準的な画像操作機能を提供するインターフェース
+    /// </summary>
+    public interface IImage : IImageBase
+    {
+        /// <summary>
+        /// 画像のクローンを作成します。
+        /// </summary>
+        /// <returns>元の画像と同じ内容を持つ新しい画像インスタンス</returns>
+        IImage Clone();
+        
+        /// <summary>
+        /// 画像のサイズを変更します。
+        /// </summary>
+        /// <param name="width">新しい幅</param>
+        /// <param name="height">新しい高さ</param>
+        /// <returns>リサイズされた新しい画像インスタンス</returns>
+        Task<IImage> ResizeAsync(int width, int height);
+    }
+}

--- a/Baketa.Core/Abstractions/Imaging/IImageBase.cs
+++ b/Baketa.Core/Abstractions/Imaging/IImageBase.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Imaging
+{
+    /// <summary>
+    /// 基本的な画像プロパティを提供する基底インターフェース
+    /// </summary>
+    public interface IImageBase : IDisposable
+    {
+        /// <summary>
+        /// 画像の幅（ピクセル単位）
+        /// </summary>
+        int Width { get; }
+
+        /// <summary>
+        /// 画像の高さ（ピクセル単位）
+        /// </summary>
+        int Height { get; }
+        
+        /// <summary>
+        /// 画像をバイト配列に変換します。
+        /// </summary>
+        /// <returns>画像データを表すバイト配列</returns>
+        Task<byte[]> ToByteArrayAsync();
+    }
+}

--- a/Baketa.Core/Abstractions/Imaging/IImageConverter.cs
+++ b/Baketa.Core/Abstractions/Imaging/IImageConverter.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Imaging
+{
+    /// <summary>
+    /// 異なる画像表現間の変換を行うインターフェース
+    /// </summary>
+    /// <typeparam name="TSource">変換元の画像型</typeparam>
+    /// <typeparam name="TTarget">変換先の画像型</typeparam>
+    public interface IImageConverter<TSource, TTarget>
+    {
+        /// <summary>
+        /// ソース画像を対象の形式に変換します。
+        /// </summary>
+        /// <param name="source">変換元の画像</param>
+        /// <returns>変換された画像</returns>
+        Task<TTarget> ConvertAsync(TSource source);
+        
+        /// <summary>
+        /// 指定されたソース画像を変換できるかどうかを確認します。
+        /// </summary>
+        /// <param name="source">検証する画像</param>
+        /// <returns>変換可能な場合はtrue、そうでない場合はfalse</returns>
+        bool CanConvert(TSource source);
+    }
+    
+    /// <summary>
+    /// 画像変換器のファクトリーインターフェース
+    /// </summary>
+    public interface IImageConverterFactory
+    {
+        /// <summary>
+        /// 指定された型の変換に対応した画像変換器を取得します。
+        /// </summary>
+        /// <typeparam name="TSource">変換元の画像型</typeparam>
+        /// <typeparam name="TTarget">変換先の画像型</typeparam>
+        /// <returns>画像変換器のインスタンス</returns>
+        IImageConverter<TSource, TTarget> GetConverter<TSource, TTarget>();
+        
+        /// <summary>
+        /// 指定された型の変換に対応した画像変換器が存在するか確認します。
+        /// </summary>
+        /// <typeparam name="TSource">変換元の画像型</typeparam>
+        /// <typeparam name="TTarget">変換先の画像型</typeparam>
+        /// <returns>変換器が存在する場合はtrue、そうでない場合はfalse</returns>
+        bool HasConverter<TSource, TTarget>();
+    }
+}

--- a/Baketa.Core/Abstractions/Imaging/IImageFactory.cs
+++ b/Baketa.Core/Abstractions/Imaging/IImageFactory.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Imaging
+{
+    /// <summary>
+    /// 画像オブジェクトの生成を担当するファクトリーインターフェース
+    /// </summary>
+    public interface IImageFactory
+    {
+        /// <summary>
+        /// ファイルから画像を作成します。
+        /// </summary>
+        /// <param name="filePath">画像ファイルパス</param>
+        /// <returns>作成された画像</returns>
+        Task<IImage> CreateFromFileAsync(string filePath);
+        
+        /// <summary>
+        /// バイト配列から画像を作成します。
+        /// </summary>
+        /// <param name="imageData">画像データ</param>
+        /// <returns>作成された画像</returns>
+        Task<IImage> CreateFromBytesAsync(byte[] imageData);
+        
+        /// <summary>
+        /// ストリームから画像を作成します。
+        /// </summary>
+        /// <param name="stream">画像データを含むストリーム</param>
+        /// <returns>作成された画像</returns>
+        Task<IImage> CreateFromStreamAsync(Stream stream);
+        
+        /// <summary>
+        /// 指定されたサイズの空の画像を作成します。
+        /// </summary>
+        /// <param name="width">画像の幅</param>
+        /// <param name="height">画像の高さ</param>
+        /// <returns>作成された画像</returns>
+        Task<IImage> CreateEmptyAsync(int width, int height);
+        
+        /// <summary>
+        /// 高度な画像処理機能を持つ画像インスタンスに変換します。
+        /// </summary>
+        /// <param name="image">元の画像</param>
+        /// <returns>高度な画像処理機能を持つ画像インスタンス</returns>
+        IAdvancedImage ConvertToAdvancedImage(IImage image);
+    }
+}

--- a/Baketa.Core/Abstractions/Imaging/IImageProcessor.cs
+++ b/Baketa.Core/Abstractions/Imaging/IImageProcessor.cs
@@ -1,0 +1,96 @@
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Imaging
+{
+    /// <summary>
+    /// 画像処理機能を提供するインターフェース
+    /// </summary>
+    public interface IImageProcessor
+    {
+        /// <summary>
+        /// OCR処理のための画像を最適化します。
+        /// </summary>
+        /// <param name="image">元の画像</param>
+        /// <returns>OCR用に最適化された画像</returns>
+        Task<IImage> OptimizeForOcrAsync(IImage image);
+        
+        /// <summary>
+        /// 画像のノイズを除去します。
+        /// </summary>
+        /// <param name="image">元の画像</param>
+        /// <param name="strength">ノイズ除去の強度（0.0〜1.0）</param>
+        /// <returns>ノイズが除去された画像</returns>
+        Task<IImage> RemoveNoiseAsync(IImage image, float strength = 0.5f);
+        
+        /// <summary>
+        /// 画像のコントラストを調整します。
+        /// </summary>
+        /// <param name="image">元の画像</param>
+        /// <param name="factor">コントラスト調整係数（1.0が元の画像、大きいほど強調）</param>
+        /// <returns>コントラストが調整された画像</returns>
+        Task<IImage> AdjustContrastAsync(IImage image, float factor);
+        
+        /// <summary>
+        /// 画像の明るさを調整します。
+        /// </summary>
+        /// <param name="image">元の画像</param>
+        /// <param name="factor">明るさ調整係数（0.0〜2.0、1.0が元の画像）</param>
+        /// <returns>明るさが調整された画像</returns>
+        Task<IImage> AdjustBrightnessAsync(IImage image, float factor);
+        
+        /// <summary>
+        /// 画像のテキスト領域を検出します。
+        /// </summary>
+        /// <param name="image">元の画像</param>
+        /// <returns>検出されたテキスト領域の配列</returns>
+        Task<TextRegion[]> DetectTextRegionsAsync(IImage image);
+    }
+    
+    /// <summary>
+    /// テキスト領域を表す構造体
+    /// </summary>
+    public readonly struct TextRegion
+    {
+        /// <summary>
+        /// X座標
+        /// </summary>
+        public int X { get; }
+        
+        /// <summary>
+        /// Y座標
+        /// </summary>
+        public int Y { get; }
+        
+        /// <summary>
+        /// 幅
+        /// </summary>
+        public int Width { get; }
+        
+        /// <summary>
+        /// 高さ
+        /// </summary>
+        public int Height { get; }
+        
+        /// <summary>
+        /// テキスト領域である確率（0.0〜1.0）
+        /// </summary>
+        public float Confidence { get; }
+        
+        /// <summary>
+        /// テキスト領域を初期化します。
+        /// </summary>
+        /// <param name="x">X座標</param>
+        /// <param name="y">Y座標</param>
+        /// <param name="width">幅</param>
+        /// <param name="height">高さ</param>
+        /// <param name="confidence">確率（0.0〜1.0）</param>
+        public TextRegion(int x, int y, int width, int height, float confidence)
+        {
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+            Confidence = confidence;
+        }
+    }
+}

--- a/Baketa.Core/Interfaces/Image/IImage.cs
+++ b/Baketa.Core/Interfaces/Image/IImage.cs
@@ -6,6 +6,8 @@ namespace Baketa.Core.Interfaces.Image
     /// <summary>
     /// 画像抽象化の基本インターフェース
     /// </summary>
+    // 注: 後の段階で非推奨化予定
+    // [Obsolete("このインターフェースは非推奨です。代わりに Baketa.Core.Abstractions.Imaging.IImage を使用してください。")]
     public interface IImage : IDisposable
     {
         /// <summary>


### PR DESCRIPTION
## 概要
このPRでは、Baketaプロジェクトの中核となる画像処理インターフェースを新しい名前空間構造へ移行し、機能拡張を行いました。これにより、OCRやキャプチャ機能の基盤が強化され、より柔軟な画像処理が可能になります。

## 実装内容

### 1. 階層的なインターフェース設計
- **IImageBase**: 基本プロパティ（幅、高さ、バイト変換）を持つ基底インターフェース
- **IImage**: IImageBaseを継承し、基本的な画像操作（クローン、リサイズ）を追加
- **IAdvancedImage**: 高度な処理（フィルター適用、類似度計算、切り抜き、回転）を定義

### 2. 機能拡張インターフェース
- **IImageConverter<TSource, TTarget>**: 異なる画像表現間の型安全な変換
- **IImageProcessor**: OCR最適化などの画像処理機能
- **IImageFactory**: 様々な方法での画像生成と変換

### 3. 構造体と列挙型
- **TextRegion**: テキスト領域の位置と信頼度を表す構造体
- **ImageFilterType**: 画像フィルタの種類を定義する列挙型

## 技術的な判断
- 階層的インターフェース設計により、基本機能と高度な機能を明確に分離
- ジェネリック型による型安全な画像変換
- 非同期メソッドによる効率的な画像処理
- 既存インターフェースは段階的な移行を容易にするため、実装クラスの移行完了後に非推奨化予定

## テスト方法
- ビルドが正常に完了すること（今回はインターフェース定義のみのため単体テストは不要）

## 関連Issue
- #1 改善: 新インターフェース構造への移行 (親Issue)
- #5 実装: 画像処理抽象化レイヤーの拡張 (関連Issue)

## 今後の作業
1. これらの新しいインターフェースを実装するクラスの開発
2. 既存コードの新インターフェースへの移行
3. 移行完了後の旧インターフェースの非推奨化

closes #3