### PR TITLE
feat: プラットフォームインターフェースの移行と拡張 (Issue #4)

### DIFF
--- a/Baketa.Core/Abstractions/DI/IServiceModule.cs
+++ b/Baketa.Core/Abstractions/DI/IServiceModule.cs
@@ -1,0 +1,34 @@
+namespace Baketa.Core.Abstractions.DI
+{
+    /// <summary>
+    /// サービス登録モジュールインターフェース
+    /// </summary>
+    public interface IServiceModule
+    {
+        /// <summary>
+        /// サービスの登録
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        void RegisterServices(object services);
+        
+        /// <summary>
+        /// モジュール名
+        /// </summary>
+        string Name { get; }
+        
+        /// <summary>
+        /// モジュールの説明
+        /// </summary>
+        string Description { get; }
+        
+        /// <summary>
+        /// モジュールの優先順位（低い値ほど先に登録される）
+        /// </summary>
+        int Priority { get; }
+        
+        /// <summary>
+        /// 依存するモジュール名の配列
+        /// </summary>
+        string[] Dependencies { get; }
+    }
+}

--- a/Baketa.Core/Abstractions/Events/IEvent.cs
+++ b/Baketa.Core/Abstractions/Events/IEvent.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Baketa.Core.Abstractions.Events
+{
+    /// <summary>
+    /// 基本イベントインターフェース
+    /// </summary>
+    public interface IEvent
+    {
+        /// <summary>
+        /// イベントID
+        /// </summary>
+        Guid Id { get; }
+        
+        /// <summary>
+        /// イベント発生時刻
+        /// </summary>
+        DateTime Timestamp { get; }
+        
+        /// <summary>
+        /// イベント名
+        /// </summary>
+        string Name { get; }
+        
+        /// <summary>
+        /// イベントカテゴリ
+        /// </summary>
+        string Category { get; }
+    }
+}

--- a/Baketa.Core/Abstractions/Events/IEventAggregator.cs
+++ b/Baketa.Core/Abstractions/Events/IEventAggregator.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Events
+{
+    /// <summary>
+    /// イベント集約インターフェース
+    /// </summary>
+    public interface IEventAggregator
+    {
+        /// <summary>
+        /// イベントの発行
+        /// </summary>
+        /// <typeparam name="TEvent">イベント型</typeparam>
+        /// <param name="event">イベント</param>
+        Task PublishAsync<TEvent>(TEvent @event) where TEvent : IEvent;
+        
+        /// <summary>
+        /// イベントハンドラの登録
+        /// </summary>
+        /// <typeparam name="TEvent">イベント型</typeparam>
+        /// <param name="handler">ハンドラ</param>
+        void Subscribe<TEvent>(IEventHandler<TEvent> handler) where TEvent : IEvent;
+        
+        /// <summary>
+        /// イベントハンドラの登録解除
+        /// </summary>
+        /// <typeparam name="TEvent">イベント型</typeparam>
+        /// <param name="handler">ハンドラ</param>
+        void Unsubscribe<TEvent>(IEventHandler<TEvent> handler) where TEvent : IEvent;
+        
+        /// <summary>
+        /// すべてのハンドラの登録解除
+        /// </summary>
+        void UnsubscribeAll();
+        
+        /// <summary>
+        /// 特定のイベント型に対するすべてのハンドラの登録解除
+        /// </summary>
+        /// <typeparam name="TEvent">イベント型</typeparam>
+        void UnsubscribeAllForEvent<TEvent>() where TEvent : IEvent;
+        
+        /// <summary>
+        /// オブジェクトに関連するすべてのハンドラの登録解除
+        /// </summary>
+        /// <param name="subscriber">購読者オブジェクト</param>
+        void UnsubscribeAllForSubscriber(object subscriber);
+        
+        /// <summary>
+        /// イベントハンドラーの実行時に発生するエラーイベント
+        /// </summary>
+        event EventHandler<EventHandlerErrorEventArgs> EventHandlerError;
+    }
+    
+    /// <summary>
+    /// イベントハンドラーエラーイベント引数
+    /// </summary>
+    public class EventHandlerErrorEventArgs : EventArgs
+    {
+        /// <summary>
+        /// 発生した例外
+        /// </summary>
+        public Exception Exception { get; }
+        
+        /// <summary>
+        /// 処理しようとしていたイベント
+        /// </summary>
+        public IEvent Event { get; }
+        
+        /// <summary>
+        /// 例外を発生させたハンドラー
+        /// </summary>
+        public object Handler { get; }
+        
+        /// <summary>
+        /// コンストラクター
+        /// </summary>
+        /// <param name="exception">発生した例外</param>
+        /// <param name="event">処理しようとしていたイベント</param>
+        /// <param name="handler">例外を発生させたハンドラー</param>
+        public EventHandlerErrorEventArgs(Exception exception, IEvent @event, object handler)
+        {
+            Exception = exception;
+            Event = @event;
+            Handler = handler;
+        }
+    }
+}

--- a/Baketa.Core/Abstractions/Events/IEventHandler.cs
+++ b/Baketa.Core/Abstractions/Events/IEventHandler.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Events
+{
+    /// <summary>
+    /// イベントハンドラインターフェース
+    /// </summary>
+    /// <typeparam name="TEvent">イベント型</typeparam>
+    public interface IEventHandler<in TEvent> where TEvent : IEvent
+    {
+        /// <summary>
+        /// イベント処理
+        /// </summary>
+        /// <param name="event">イベント</param>
+        Task HandleAsync(TEvent @event);
+        
+        /// <summary>
+        /// このハンドラーの優先度
+        /// </summary>
+        int Priority { get; }
+        
+        /// <summary>
+        /// 処理を同期的に実行するかどうか
+        /// </summary>
+        bool SynchronousExecution { get; }
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/IPlatform.cs
+++ b/Baketa.Core/Abstractions/Platform/IPlatform.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Baketa.Core.Abstractions.Platform
+{
+    /// <summary>
+    /// プラットフォーム抽象化の基本インターフェース
+    /// </summary>
+    public interface IPlatform
+    {
+        /// <summary>
+        /// プラットフォーム名
+        /// </summary>
+        string Name { get; }
+        
+        /// <summary>
+        /// プラットフォームバージョン
+        /// </summary>
+        string Version { get; }
+        
+        /// <summary>
+        /// 機能サポート確認
+        /// </summary>
+        /// <param name="featureName">機能名</param>
+        /// <returns>サポートしている場合はtrue</returns>
+        bool SupportsFeature(string featureName);
+        
+        /// <summary>
+        /// プラットフォーム固有のサービスを取得
+        /// </summary>
+        /// <typeparam name="T">サービスタイプ</typeparam>
+        /// <returns>サービスインスタンス、存在しない場合は例外をスロー</returns>
+        T GetService<T>() where T : class;
+        
+        /// <summary>
+        /// プラットフォーム固有のサービス取得を試みる
+        /// </summary>
+        /// <typeparam name="T">サービスタイプ</typeparam>
+        /// <param name="service">サービスインスタンス（出力）</param>
+        /// <returns>取得できた場合はtrue</returns>
+        bool TryGetService<T>(out T service) where T : class;
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/IPlatformDetector.cs
+++ b/Baketa.Core/Abstractions/Platform/IPlatformDetector.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Platform
+{
+    /// <summary>
+    /// プラットフォーム検出インターフェース
+    /// </summary>
+    public interface IPlatformDetector
+    {
+        /// <summary>
+        /// 現在のプラットフォームを検出
+        /// </summary>
+        /// <returns>プラットフォーム情報</returns>
+        IPlatform DetectCurrentPlatform();
+        
+        /// <summary>
+        /// 非同期で現在のプラットフォームを検出
+        /// </summary>
+        /// <returns>プラットフォーム情報</returns>
+        Task<IPlatform> DetectCurrentPlatformAsync();
+        
+        /// <summary>
+        /// Windows環境かどうかを確認
+        /// </summary>
+        /// <returns>Windows環境の場合はtrue</returns>
+        bool IsWindows();
+        
+        /// <summary>
+        /// 特定のプラットフォーム機能がサポートされているか確認
+        /// </summary>
+        /// <param name="featureName">機能名</param>
+        /// <returns>サポートされている場合はtrue</returns>
+        bool IsPlatformFeatureSupported(string featureName);
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/Windows/Adapters/IWindowManagerAdapter.cs
+++ b/Baketa.Core/Abstractions/Platform/Windows/Adapters/IWindowManagerAdapter.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace Baketa.Core.Abstractions.Platform.Windows.Adapters
+{
+    /// <summary>
+    /// WindowManagerをコアウィンドウ管理サービスに変換するアダプターインターフェース
+    /// </summary>
+    public interface IWindowManagerAdapter : IWindowsAdapter
+    {
+        /// <summary>
+        /// アクティブなウィンドウハンドルを取得
+        /// </summary>
+        /// <returns>アクティブウィンドウのハンドル</returns>
+        IntPtr GetActiveWindowHandle();
+        
+        /// <summary>
+        /// 指定したタイトルを持つウィンドウハンドルを取得
+        /// </summary>
+        /// <param name="title">ウィンドウタイトル (部分一致)</param>
+        /// <returns>一致するウィンドウのハンドル。見つからなければIntPtr.Zero</returns>
+        IntPtr FindWindowByTitle(string title);
+        
+        /// <summary>
+        /// 指定したクラス名を持つウィンドウハンドルを取得
+        /// </summary>
+        /// <param name="className">ウィンドウクラス名</param>
+        /// <returns>一致するウィンドウのハンドル。見つからなければIntPtr.Zero</returns>
+        IntPtr FindWindowByClass(string className);
+        
+        /// <summary>
+        /// ウィンドウの位置とサイズを取得
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <returns>ウィンドウの位置とサイズを表す Rectangle</returns>
+        Rectangle? GetWindowBounds(IntPtr handle);
+        
+        /// <summary>
+        /// ウィンドウのクライアント領域を取得
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <returns>クライアント領域の位置とサイズを表す Rectangle</returns>
+        Rectangle? GetClientBounds(IntPtr handle);
+        
+        /// <summary>
+        /// ウィンドウのタイトルを取得
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <returns>ウィンドウタイトル</returns>
+        string GetWindowTitle(IntPtr handle);
+        
+        /// <summary>
+        /// 実行中のアプリケーションのウィンドウリストを取得（プラットフォーム共通のオブジェクトで表現）
+        /// </summary>
+        /// <returns>ウィンドウ情報のリスト</returns>
+        List<WindowInfo> GetRunningApplicationWindows();
+    }
+    
+    /// <summary>
+    /// プラットフォーム共通のウィンドウ情報
+    /// </summary>
+    public class WindowInfo
+    {
+        /// <summary>
+        /// ウィンドウハンドル（プラットフォーム固有）
+        /// </summary>
+        public IntPtr Handle { get; set; }
+        
+        /// <summary>
+        /// ウィンドウタイトル
+        /// </summary>
+        public required string Title { get; set; }
+        
+        /// <summary>
+        /// ウィンドウの位置とサイズ
+        /// </summary>
+        public Rectangle Bounds { get; set; }
+        
+        /// <summary>
+        /// 可視状態
+        /// </summary>
+        public bool IsVisible { get; set; }
+        
+        /// <summary>
+        /// 最小化状態
+        /// </summary>
+        public bool IsMinimized { get; set; }
+        
+        /// <summary>
+        /// 最大化状態
+        /// </summary>
+        public bool IsMaximized { get; set; }
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/Windows/Adapters/IWindowsAdapter.cs
+++ b/Baketa.Core/Abstractions/Platform/Windows/Adapters/IWindowsAdapter.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Baketa.Core.Abstractions.Platform.Windows.Adapters
+{
+    /// <summary>
+    /// Windows固有実装とコア抽象化レイヤー間のアダプター基本インターフェース
+    /// </summary>
+    public interface IWindowsAdapter
+    {
+        /// <summary>
+        /// アダプターがサポートする機能名
+        /// </summary>
+        string FeatureName { get; }
+        
+        /// <summary>
+        /// 特定の型変換をサポートするかどうか
+        /// </summary>
+        /// <typeparam name="TSource">ソース型</typeparam>
+        /// <typeparam name="TTarget">ターゲット型</typeparam>
+        /// <returns>サポートする場合はtrue</returns>
+        bool SupportsConversion<TSource, TTarget>();
+        
+        /// <summary>
+        /// 変換を試行
+        /// </summary>
+        /// <typeparam name="TSource">ソース型</typeparam>
+        /// <typeparam name="TTarget">ターゲット型</typeparam>
+        /// <param name="source">ソースオブジェクト</param>
+        /// <param name="target">変換結果（出力）</param>
+        /// <returns>変換成功時はtrue</returns>
+        bool TryConvert<TSource, TTarget>(TSource source, out TTarget target) where TSource : class where TTarget : class;
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/Windows/Adapters/IWindowsCapturerAdapter.cs
+++ b/Baketa.Core/Abstractions/Platform/Windows/Adapters/IWindowsCapturerAdapter.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Drawing;
+using System.Threading.Tasks;
+using Baketa.Core.Abstractions.Imaging;
+
+namespace Baketa.Core.Abstractions.Platform.Windows.Adapters
+{
+    /// <summary>
+    /// WindowsCapturerをコアキャプチャサービスに変換するアダプターインターフェース
+    /// </summary>
+    public interface IWindowsCapturerAdapter : IWindowsAdapter
+    {
+        /// <summary>
+        /// 画面全体をキャプチャしてコア画像として返す
+        /// </summary>
+        /// <returns>キャプチャした画像</returns>
+        Task<IImage> CaptureScreenAsync();
+        
+        /// <summary>
+        /// 指定した領域をキャプチャしてコア画像として返す
+        /// </summary>
+        /// <param name="region">キャプチャする領域</param>
+        /// <returns>キャプチャした画像</returns>
+        Task<IImage> CaptureRegionAsync(Rectangle region);
+        
+        /// <summary>
+        /// 指定したウィンドウをキャプチャしてコア画像として返す
+        /// </summary>
+        /// <param name="windowHandle">ウィンドウハンドル</param>
+        /// <returns>キャプチャした画像</returns>
+        Task<IImage> CaptureWindowAsync(IntPtr windowHandle);
+        
+        /// <summary>
+        /// 指定したウィンドウのクライアント領域をキャプチャしてコア画像として返す
+        /// </summary>
+        /// <param name="windowHandle">ウィンドウハンドル</param>
+        /// <returns>キャプチャした画像</returns>
+        Task<IImage> CaptureClientAreaAsync(IntPtr windowHandle);
+        
+        /// <summary>
+        /// キャプチャオプションを設定（内部でWindowsCaptureOptionsに変換）
+        /// </summary>
+        /// <param name="quality">キャプチャ品質 (1-100)</param>
+        /// <param name="includeCursor">カーソルを含むかどうか</param>
+        void SetCaptureOptions(int quality, bool includeCursor);
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/Windows/Adapters/IWindowsImageAdapter.cs
+++ b/Baketa.Core/Abstractions/Platform/Windows/Adapters/IWindowsImageAdapter.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+using Baketa.Core.Abstractions.Imaging;
+
+namespace Baketa.Core.Abstractions.Platform.Windows.Adapters
+{
+    /// <summary>
+    /// Windows画像をコア画像に変換するアダプターインターフェース
+    /// </summary>
+    public interface IWindowsImageAdapter : IWindowsAdapter
+    {
+        /// <summary>
+        /// Windows画像をコア画像に変換
+        /// </summary>
+        /// <param name="windowsImage">Windows画像</param>
+        /// <returns>コア画像インターフェース</returns>
+        IImage AdaptToImage(IWindowsImage windowsImage);
+        
+        /// <summary>
+        /// コア画像をWindows画像に変換（可能な場合）
+        /// </summary>
+        /// <param name="image">コア画像</param>
+        /// <returns>Windows画像、変換できない場合はnull</returns>
+        IWindowsImage AdaptToWindowsImage(IImage image);
+        
+        /// <summary>
+        /// 非同期でWindows画像をコア画像に変換
+        /// </summary>
+        /// <param name="windowsImage">Windows画像</param>
+        /// <returns>コア画像インターフェース</returns>
+        Task<IImage> AdaptToImageAsync(IWindowsImage windowsImage);
+        
+        /// <summary>
+        /// 非同期でコア画像をWindows画像に変換（可能な場合）
+        /// </summary>
+        /// <param name="image">コア画像</param>
+        /// <returns>Windows画像</returns>
+        Task<IWindowsImage> AdaptToWindowsImageAsync(IImage image);
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/Windows/IWindowManager.cs
+++ b/Baketa.Core/Abstractions/Platform/Windows/IWindowManager.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Platform.Windows
+{
+    /// <summary>
+    /// Windowsウィンドウ管理インターフェース
+    /// </summary>
+    public interface IWindowManager
+    {
+        /// <summary>
+        /// アクティブなウィンドウハンドルを取得
+        /// </summary>
+        /// <returns>アクティブウィンドウのハンドル</returns>
+        IntPtr GetActiveWindowHandle();
+        
+        /// <summary>
+        /// 指定したタイトルを持つウィンドウハンドルを取得
+        /// </summary>
+        /// <param name="title">ウィンドウタイトル (部分一致)</param>
+        /// <returns>一致するウィンドウのハンドル。見つからなければIntPtr.Zero</returns>
+        IntPtr FindWindowByTitle(string title);
+        
+        /// <summary>
+        /// 指定したクラス名を持つウィンドウハンドルを取得
+        /// </summary>
+        /// <param name="className">ウィンドウクラス名</param>
+        /// <returns>一致するウィンドウのハンドル。見つからなければIntPtr.Zero</returns>
+        IntPtr FindWindowByClass(string className);
+        
+        /// <summary>
+        /// ウィンドウの位置とサイズを取得
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <returns>ウィンドウの位置とサイズを表す Rectangle</returns>
+        Rectangle? GetWindowBounds(IntPtr handle);
+        
+        /// <summary>
+        /// ウィンドウのクライアント領域を取得
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <returns>クライアント領域の位置とサイズを表す Rectangle</returns>
+        Rectangle? GetClientBounds(IntPtr handle);
+        
+        /// <summary>
+        /// ウィンドウのタイトルを取得
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <returns>ウィンドウタイトル</returns>
+        string GetWindowTitle(IntPtr handle);
+        
+        /// <summary>
+        /// ウィンドウが最小化されているか確認
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <returns>最小化されている場合はtrue</returns>
+        bool IsMinimized(IntPtr handle);
+        
+        /// <summary>
+        /// ウィンドウが最大化されているか確認
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <returns>最大化されている場合はtrue</returns>
+        bool IsMaximized(IntPtr handle);
+        
+        /// <summary>
+        /// ウィンドウの位置とサイズを設定
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <param name="bounds">新しい位置とサイズ</param>
+        /// <returns>成功した場合はtrue</returns>
+        bool SetWindowBounds(IntPtr handle, Rectangle bounds);
+        
+        /// <summary>
+        /// ウィンドウの透明度を設定
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <param name="opacity">透明度 (0.0-1.0)</param>
+        /// <returns>成功した場合はtrue</returns>
+        bool SetWindowOpacity(IntPtr handle, double opacity);
+        
+        /// <summary>
+        /// ウィンドウを前面に表示
+        /// </summary>
+        /// <param name="handle">ウィンドウハンドル</param>
+        /// <returns>成功した場合はtrue</returns>
+        bool BringWindowToFront(IntPtr handle);
+        
+        /// <summary>
+        /// 実行中のアプリケーションのウィンドウリストを取得
+        /// </summary>
+        /// <returns>ウィンドウハンドルとタイトルのディクショナリ</returns>
+        Dictionary<IntPtr, string> GetRunningApplicationWindows();
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/Windows/IWindowsCapturer.cs
+++ b/Baketa.Core/Abstractions/Platform/Windows/IWindowsCapturer.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Drawing;
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Platform.Windows
+{
+    /// <summary>
+    /// Windows画面キャプチャインターフェース
+    /// </summary>
+    public interface IWindowsCapturer
+    {
+        /// <summary>
+        /// 画面全体をキャプチャ
+        /// </summary>
+        /// <returns>キャプチャした画像</returns>
+        Task<IWindowsImage> CaptureScreenAsync();
+        
+        /// <summary>
+        /// 指定した領域をキャプチャ
+        /// </summary>
+        /// <param name="region">キャプチャする領域</param>
+        /// <returns>キャプチャした画像</returns>
+        Task<IWindowsImage> CaptureRegionAsync(Rectangle region);
+        
+        /// <summary>
+        /// 指定したウィンドウをキャプチャ
+        /// </summary>
+        /// <param name="windowHandle">ウィンドウハンドル</param>
+        /// <returns>キャプチャした画像</returns>
+        Task<IWindowsImage> CaptureWindowAsync(IntPtr windowHandle);
+        
+        /// <summary>
+        /// 指定したウィンドウのクライアント領域をキャプチャ
+        /// </summary>
+        /// <param name="windowHandle">ウィンドウハンドル</param>
+        /// <returns>キャプチャした画像</returns>
+        Task<IWindowsImage> CaptureClientAreaAsync(IntPtr windowHandle);
+        
+        /// <summary>
+        /// キャプチャオプションを設定
+        /// </summary>
+        /// <param name="options">キャプチャオプション</param>
+        void SetCaptureOptions(WindowsCaptureOptions options);
+        
+        /// <summary>
+        /// 現在のキャプチャオプションを取得
+        /// </summary>
+        /// <returns>キャプチャオプション</returns>
+        WindowsCaptureOptions GetCaptureOptions();
+    }
+    
+    /// <summary>
+    /// Windowsキャプチャオプション
+    /// </summary>
+    public class WindowsCaptureOptions
+    {
+        /// <summary>
+        /// キャプチャのクオリティ（1-100）
+        /// </summary>
+        public int Quality { get; set; } = 100;
+        
+        /// <summary>
+        /// ウィンドウキャプチャ時に装飾（タイトルバーなど）を含むかどうか
+        /// </summary>
+        public bool IncludeWindowDecorations { get; set; } = true;
+        
+        /// <summary>
+        /// カーソルを含むかどうか
+        /// </summary>
+        public bool IncludeCursor { get; set; } = false;
+        
+        /// <summary>
+        /// 透過ウィンドウの透過部分を維持するかどうか
+        /// </summary>
+        public bool PreserveTransparency { get; set; } = true;
+        
+        /// <summary>
+        /// DWM（Desktop Window Manager）レンダリングを使用するかどうか
+        /// </summary>
+        public bool UseDwmCapture { get; set; } = true;
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/Windows/IWindowsImage.cs
+++ b/Baketa.Core/Abstractions/Platform/Windows/IWindowsImage.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Drawing;
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Platform.Windows
+{
+    /// <summary>
+    /// Windows固有の画像インターフェース
+    /// </summary>
+    public interface IWindowsImage : IDisposable
+    {
+        /// <summary>
+        /// 画像の幅
+        /// </summary>
+        int Width { get; }
+
+        /// <summary>
+        /// 画像の高さ
+        /// </summary>
+        int Height { get; }
+
+        /// <summary>
+        /// ネイティブImageオブジェクトを取得
+        /// </summary>
+        /// <returns>System.Drawing.Image インスタンス</returns>
+        Image GetNativeImage();
+
+        /// <summary>
+        /// Bitmapとして取得
+        /// </summary>
+        /// <returns>System.Drawing.Bitmap インスタンス</returns>
+        Bitmap GetBitmap();
+        
+        /// <summary>
+        /// 指定したパスに画像を保存
+        /// </summary>
+        /// <param name="path">保存先パス</param>
+        /// <param name="format">画像フォーマット（省略時はPNG）</param>
+        /// <returns>非同期タスク</returns>
+        Task SaveAsync(string path, System.Drawing.Imaging.ImageFormat? format = null);
+        
+        /// <summary>
+        /// 画像のサイズを変更
+        /// </summary>
+        /// <param name="width">新しい幅</param>
+        /// <param name="height">新しい高さ</param>
+        /// <returns>リサイズされた新しい画像インスタンス</returns>
+        Task<IWindowsImage> ResizeAsync(int width, int height);
+        
+        /// <summary>
+        /// 画像の一部を切り取る
+        /// </summary>
+        /// <param name="rectangle">切り取る領域</param>
+        /// <returns>切り取られた新しい画像インスタンス</returns>
+        Task<IWindowsImage> CropAsync(Rectangle rectangle);
+        
+        /// <summary>
+        /// 画像をバイト配列に変換
+        /// </summary>
+        /// <param name="format">画像フォーマット（省略時はPNG）</param>
+        /// <returns>画像データのバイト配列</returns>
+        Task<byte[]> ToByteArrayAsync(System.Drawing.Imaging.ImageFormat? format = null);
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/Windows/IWindowsImageFactory.cs
+++ b/Baketa.Core/Abstractions/Platform/Windows/IWindowsImageFactory.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Drawing;
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Platform.Windows
+{
+    /// <summary>
+    /// Windows画像ファクトリインターフェース
+    /// </summary>
+    public interface IWindowsImageFactory
+    {
+        /// <summary>
+        /// ファイルから画像を作成
+        /// </summary>
+        /// <param name="filePath">ファイルパス</param>
+        /// <returns>Windows画像</returns>
+        Task<IWindowsImage> CreateFromFileAsync(string filePath);
+        
+        /// <summary>
+        /// バイト配列から画像を作成
+        /// </summary>
+        /// <param name="data">画像データ</param>
+        /// <returns>Windows画像</returns>
+        Task<IWindowsImage> CreateFromBytesAsync(byte[] data);
+        
+        /// <summary>
+        /// Bitmapから画像を作成
+        /// </summary>
+        /// <param name="bitmap">Bitmap</param>
+        /// <returns>Windows画像</returns>
+        IWindowsImage CreateFromBitmap(Bitmap bitmap);
+        
+        /// <summary>
+        /// 指定されたサイズの空の画像を作成
+        /// </summary>
+        /// <param name="width">幅</param>
+        /// <param name="height">高さ</param>
+        /// <param name="backgroundColor">背景色（省略時は透明）</param>
+        /// <returns>Windows画像</returns>
+        Task<IWindowsImage> CreateEmptyAsync(int width, int height, Color? backgroundColor = null);
+    }
+}

--- a/Baketa.Core/Abstractions/Platform/Windows/IWindowsPlatform.cs
+++ b/Baketa.Core/Abstractions/Platform/Windows/IWindowsPlatform.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Baketa.Core.Abstractions.Platform.Windows
+{
+    /// <summary>
+    /// Windows固有のプラットフォーム機能を提供するインターフェース
+    /// </summary>
+    public interface IWindowsPlatform : IPlatform
+    {
+        /// <summary>
+        /// Windows画像ファクトリを取得
+        /// </summary>
+        IWindowsImageFactory ImageFactory { get; }
+        
+        /// <summary>
+        /// Windowsキャプチャサービスを取得
+        /// </summary>
+        IWindowsCapturer Capturer { get; }
+        
+        /// <summary>
+        /// Windowsウィンドウ管理サービスを取得
+        /// </summary>
+        IWindowManager WindowManager { get; }
+        
+        /// <summary>
+        /// Windowsバージョン
+        /// </summary>
+        Version WindowsVersion { get; }
+        
+        /// <summary>
+        /// DWM（Desktop Window Manager）が有効かどうか
+        /// </summary>
+        bool IsDwmEnabled { get; }
+        
+        /// <summary>
+        /// 管理者権限で実行されているかどうか
+        /// </summary>
+        bool IsRunningAsAdministrator { get; }
+        
+        /// <summary>
+        /// システム情報を取得
+        /// </summary>
+        /// <returns>システム情報</returns>
+        Task<WindowsSystemInfo> GetSystemInfoAsync();
+    }
+    
+    /// <summary>
+    /// Windowsシステム情報
+    /// </summary>
+    public class WindowsSystemInfo
+    {
+        /// <summary>
+        /// オペレーティングシステム名
+        /// </summary>
+        public required string OsName { get; set; }
+        
+        /// <summary>
+        /// オペレーティングシステムバージョン
+        /// </summary>
+        public required Version OsVersion { get; set; }
+        
+        /// <summary>
+        /// プロセッサ情報
+        /// </summary>
+        public required string ProcessorInfo { get; set; }
+        
+        /// <summary>
+        /// 合計物理メモリ (バイト)
+        /// </summary>
+        public ulong TotalPhysicalMemory { get; set; }
+        
+        /// <summary>
+        /// 利用可能な物理メモリ (バイト)
+        /// </summary>
+        public ulong AvailablePhysicalMemory { get; set; }
+        
+        /// <summary>
+        /// ディスプレイデバイス情報
+        /// </summary>
+        public required DisplayDeviceInfo[] DisplayDevices { get; set; }
+    }
+    
+    /// <summary>
+    /// ディスプレイデバイス情報
+    /// </summary>
+    public class DisplayDeviceInfo
+    {
+        /// <summary>
+        /// デバイス名
+        /// </summary>
+        public required string DeviceName { get; set; }
+        
+        /// <summary>
+        /// 解像度（幅）
+        /// </summary>
+        public int Width { get; set; }
+        
+        /// <summary>
+        /// 解像度（高さ）
+        /// </summary>
+        public int Height { get; set; }
+        
+        /// <summary>
+        /// リフレッシュレート (Hz)
+        /// </summary>
+        public int RefreshRate { get; set; }
+        
+        /// <summary>
+        /// ビットデプス
+        /// </summary>
+        public int BitsPerPixel { get; set; }
+        
+        /// <summary>
+        /// プライマリディスプレイかどうか
+        /// </summary>
+        public bool IsPrimary { get; set; }
+    }
+}

--- a/Baketa.Core/Interfaces/Image/IImage.cs
+++ b/Baketa.Core/Interfaces/Image/IImage.cs
@@ -6,8 +6,8 @@ namespace Baketa.Core.Interfaces.Image
     /// <summary>
     /// 画像抽象化の基本インターフェース
     /// </summary>
-    // 注: 後の段階で非推奨化予定
-    // [Obsolete("このインターフェースは非推奨です。代わりに Baketa.Core.Abstractions.Imaging.IImage を使用してください。")]
+    // 非推奨化実装
+    [Obsolete("このインターフェースは非推奨です。代わりに Baketa.Core.Abstractions.Imaging.IImage を使用してください。")]
     public interface IImage : IDisposable
     {
         /// <summary>

--- a/Baketa.Infrastructure.Platform/Abstractions/IWindowsImage.cs
+++ b/Baketa.Infrastructure.Platform/Abstractions/IWindowsImage.cs
@@ -6,6 +6,7 @@ namespace Baketa.Infrastructure.Platform.Abstractions
     /// <summary>
     /// Windows固有画像インターフェース
     /// </summary>
+    [Obsolete("このインターフェースは非推奨です。代わりに Baketa.Core.Abstractions.Platform.Windows.IWindowsImage を使用してください。")]
     public interface IWindowsImage : IDisposable
     {
         /// <summary>


### PR DESCRIPTION
# プラットフォームインターフェースの移行と拡張

## 概要
Issue #4「プラットフォームインターフェースの移行と拡張」の実装を完了しました。
プラットフォーム依存コードと抽象化レイヤー間の明確な境界を確立し、
アダプターパターンを活用した拡張性のある設計を導入しました。

## 変更内容

### 新しいディレクトリ構造
- `Baketa.Core.Abstractions.Platform` 名前空間の作成
- `Baketa.Core.Abstractions.Platform.Windows` 名前空間の作成
- `Baketa.Core.Abstractions.Events` 名前空間の作成
- `Baketa.Core.Abstractions.DI` 名前空間の作成

### 基本インターフェース
- `IPlatform` - プラットフォーム抽象化基本インターフェース
- `IPlatformDetector` - プラットフォーム検出インターフェース

### Windows固有インターフェース
- `IWindowsImage` - Windows画像インターフェース（拡張版）
- `IWindowsImageFactory` - Windows画像ファクトリインターフェース
- `IWindowsCapturer` - Windowsキャプチャインターフェース
- `IWindowManager` - Windowsウィンドウ管理インターフェース
- `IWindowsPlatform` - Windows固有機能統合インターフェース

### アダプターインターフェース
- `IWindowsAdapter` - 基本アダプターインターフェース
- `IWindowsImageAdapter` - 画像アダプターインターフェース
- `IWindowsCapturerAdapter` - キャプチャアダプターインターフェース
- `IWindowManagerAdapter` - ウィンドウ管理アダプターインターフェース

### イベント集約機構
- `IEvent` - 基本イベントインターフェース
- `IEventHandler<T>` - イベントハンドラーインターフェース
- `IEventAggregator` - イベント集約インターフェース

### サービスモジュール
- `IServiceModule` - サービス登録モジュールインターフェース

### 非推奨化処理
- 旧インターフェースへのObsolete属性追加による非推奨化

## テスト
- インターフェース定義のみの変更のため、単体テストは未実装
- コンパイル時の警告は予想通り（Issue #6で対応予定）

## 関連Issue
- 親Issue: #1 改善: 新インターフェース構造への移行
- 次ステップ: #6 改善: 非推奨化と参照更新

## 今後の課題
- これらのインターフェースに対する実装クラスの作成
- 既存クラスの新インターフェースへの移行
- 旧インターフェース参照の更新（Issue #6）