### PR TITLE
feat: IServiceModuleインターフェースとDI基盤の実装 (#13)

### DIFF
--- a/Baketa.Application/Baketa.Application.csproj
+++ b/Baketa.Application/Baketa.Application.csproj
@@ -10,8 +10,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Baketa.Application/DI/Extensions/ServiceCollectionExtensions.cs
+++ b/Baketa.Application/DI/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,114 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Baketa.Application.DI.Extensions
+{
+    /// <summary>
+    /// サービスコレクション拡張メソッド。
+    /// Baketaサービスモジュールの登録を簡略化します。
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Baketaの全サービスモジュールを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        /// <param name="scanForModules">アセンブリスキャンによるモジュール自動検出を有効にするかどうか</param>
+        /// <param name="customModules">追加の手動登録モジュール</param>
+        /// <returns>サービスコレクション</returns>
+        public static IServiceCollection AddBaketaServices(
+            this IServiceCollection services,
+            bool scanForModules = false,
+            params IServiceModule[] customModules)
+        {
+            // カスタムモジュールと基本モジュールを統合
+            var modules = customModules.ToList();
+            
+            // スキャンによるモジュール検出（オプション）
+            if (scanForModules)
+            {
+                var scannedModules = DiscoverModules();
+                modules.AddRange(scannedModules);
+            }
+            
+            // 優先度でソート
+            var sortedModules = modules
+                .Select(m => new 
+                {
+                    Module = m,
+                    Priority = m.GetType().GetCustomAttribute<ModulePriorityAttribute>()?.Priority 
+                              ?? ModulePriority.Custom
+                })
+                .OrderByDescending(x => (int)x.Priority)
+                .Select(x => x.Module)
+                .ToArray();
+            
+            // 登録
+            RegisterModules(services, sortedModules);
+            
+            return services;
+        }
+        
+        /// <summary>
+        /// モジュールを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        /// <param name="modules">登録するモジュール</param>
+        private static void RegisterModules(IServiceCollection services, IEnumerable<IServiceModule> modules)
+        {
+            var registeredModules = new HashSet<Type>();
+            
+            foreach (var module in modules)
+            {
+                if (module is ServiceModuleBase moduleBase)
+                {
+                    // ServiceModuleBase を継承している場合は依存関係を考慮して登録
+                    moduleBase.RegisterWithDependencies(services, registeredModules, new Stack<Type>());
+                }
+                else
+                {
+                    // 通常のモジュールは直接登録
+                    if (!registeredModules.Contains(module.GetType()))
+                    {
+                        module.RegisterServices(services);
+                        registeredModules.Add(module.GetType());
+                    }
+                }
+            }
+            
+            // オプショナル: 登録されたモジュールをデバッグログに出力
+            try {
+                var serviceProvider = services.BuildServiceProvider();
+                var logger = serviceProvider.GetService<ILogger<IServiceModule>>();
+                logger?.LogDebug("登録されたモジュール: {RegisteredModules}", 
+                    string.Join(", ", registeredModules.Select(t => t.Name)));
+            } catch (Exception) {
+                // ロギングに失敗しても処理を継続
+            }
+        }
+        
+        /// <summary>
+        /// アセンブリから自動登録対象のモジュールを検出します。
+        /// </summary>
+        /// <returns>検出されたモジュール</returns>
+        private static IEnumerable<IServiceModule> DiscoverModules()
+        {
+            // アプリケーションドメイン内のアセンブリから IServiceModule 実装を検索
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(a => a.GetTypes())
+                .Where(t => typeof(IServiceModule).IsAssignableFrom(t) &&
+                           !t.IsAbstract &&
+                           !t.IsInterface &&
+                           t.GetCustomAttribute<AutoRegisterAttribute>() != null)
+                .Select(t => Activator.CreateInstance(t) as IServiceModule)
+                .Where(m => m != null)!;
+        }
+    }
+}

--- a/Baketa.Application/DI/Modules/SampleApplicationModule.cs
+++ b/Baketa.Application/DI/Modules/SampleApplicationModule.cs
@@ -1,0 +1,39 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Baketa.Application.DI.Modules
+{
+    /// <summary>
+    /// サンプルのアプリケーションモジュール実装。
+    /// </summary>
+    [ModulePriority(ModulePriority.Application)]
+    public class SampleApplicationModule : ServiceModuleBase
+    {
+        /// <summary>
+        /// アプリケーションサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public override void RegisterServices(IServiceCollection services)
+        {
+            // ここで実際のサービス登録を行います
+            // 例：services.AddScoped<ITranslationService, TranslationService>();
+            
+            // サンプル用なのでログメッセージのみ出力
+            Console.WriteLine($"{nameof(SampleApplicationModule)} のサービスを登録しました。");
+        }
+        
+        /// <summary>
+        /// このモジュールが依存するモジュールを取得します。
+        /// </summary>
+        /// <returns>依存モジュールの型</returns>
+        public override IEnumerable<Type> GetDependentModules()
+        {
+            yield return typeof(SampleInfrastructureModule);
+            // 間接的にSampleCoreModuleにも依存しています（SampleInfrastructureModuleを通じて）
+        }
+    }
+}

--- a/Baketa.Application/DI/Modules/SampleCoreModule.cs
+++ b/Baketa.Application/DI/Modules/SampleCoreModule.cs
@@ -1,0 +1,29 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Baketa.Application.DI.Modules
+{
+    /// <summary>
+    /// サンプルのコアモジュール実装。
+    /// </summary>
+    [ModulePriority(ModulePriority.Core)]
+    public class SampleCoreModule : ServiceModuleBase
+    {
+        /// <summary>
+        /// コアサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public override void RegisterServices(IServiceCollection services)
+        {
+            // ここで実際のサービス登録を行います
+            // 例：services.AddSingleton<IEventAggregator, EventAggregator>();
+            
+            // サンプル用なのでログメッセージのみ出力
+            Console.WriteLine($"{nameof(SampleCoreModule)} のサービスを登録しました。");
+        }
+    }
+}

--- a/Baketa.Application/DI/Modules/SampleInfrastructureModule.cs
+++ b/Baketa.Application/DI/Modules/SampleInfrastructureModule.cs
@@ -1,0 +1,38 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Baketa.Application.DI.Modules
+{
+    /// <summary>
+    /// サンプルのインフラストラクチャモジュール実装。
+    /// </summary>
+    [ModulePriority(ModulePriority.Infrastructure)]
+    public class SampleInfrastructureModule : ServiceModuleBase
+    {
+        /// <summary>
+        /// インフラストラクチャサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public override void RegisterServices(IServiceCollection services)
+        {
+            // ここで実際のサービス登録を行います
+            // 例：services.AddSingleton<ISettingsService, SettingsService>();
+            
+            // サンプル用なのでログメッセージのみ出力
+            Console.WriteLine($"{nameof(SampleInfrastructureModule)} のサービスを登録しました。");
+        }
+        
+        /// <summary>
+        /// このモジュールが依存するモジュールを取得します。
+        /// </summary>
+        /// <returns>依存モジュールの型</returns>
+        public override IEnumerable<Type> GetDependentModules()
+        {
+            yield return typeof(SampleCoreModule);
+        }
+    }
+}

--- a/Baketa.Application/DI/Modules/SampleUIModule.cs
+++ b/Baketa.Application/DI/Modules/SampleUIModule.cs
@@ -1,0 +1,40 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Baketa.Application.DI.Modules
+{
+    /// <summary>
+    /// サンプルのUIモジュール実装。
+    /// </summary>
+    [ModulePriority(ModulePriority.UI)]
+    [AutoRegister] // 自動検出の対象としてマーク
+    public class SampleUIModule : ServiceModuleBase
+    {
+        /// <summary>
+        /// UIサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public override void RegisterServices(IServiceCollection services)
+        {
+            // ここで実際のサービス登録を行います
+            // 例：services.AddTransient<MainViewModel>();
+            
+            // サンプル用なのでログメッセージのみ出力
+            Console.WriteLine($"{nameof(SampleUIModule)} のサービスを登録しました。");
+        }
+        
+        /// <summary>
+        /// このモジュールが依存するモジュールを取得します。
+        /// </summary>
+        /// <returns>依存モジュールの型</returns>
+        public override IEnumerable<Type> GetDependentModules()
+        {
+            yield return typeof(SampleApplicationModule);
+            // 間接的に他のすべてのモジュールにも依存しています
+        }
+    }
+}

--- a/Baketa.Core/Abstractions/DI/IServiceModule.cs
+++ b/Baketa.Core/Abstractions/DI/IServiceModule.cs
@@ -1,34 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Baketa.Core.Abstractions.DI
 {
     /// <summary>
-    /// サービス登録モジュールインターフェース
+    /// サービス登録モジュールのインターフェース。
+    /// モジュール化された依存性注入パターンを実現するための基盤となります。
     /// </summary>
     public interface IServiceModule
     {
         /// <summary>
-        /// サービスの登録
+        /// このモジュールが提供するサービスを登録します。
         /// </summary>
         /// <param name="services">サービスコレクション</param>
-        void RegisterServices(object services);
-        
+        void RegisterServices(IServiceCollection services);
+
         /// <summary>
-        /// モジュール名
+        /// このモジュールが依存する他のモジュールの型を取得します。
+        /// デフォルトでは依存モジュールはありません。
         /// </summary>
-        string Name { get; }
-        
-        /// <summary>
-        /// モジュールの説明
-        /// </summary>
-        string Description { get; }
-        
-        /// <summary>
-        /// モジュールの優先順位（低い値ほど先に登録される）
-        /// </summary>
-        int Priority { get; }
-        
-        /// <summary>
-        /// 依存するモジュール名の配列
-        /// </summary>
-        string[] Dependencies { get; }
+        /// <returns>依存モジュールの型のコレクション</returns>
+        IEnumerable<Type> GetDependentModules() => [];
     }
 }

--- a/Baketa.Core/Baketa.Core.csproj
+++ b/Baketa.Core/Baketa.Core.csproj
@@ -12,6 +12,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/Baketa.Core/DI/Attributes/AutoRegisterAttribute.cs
+++ b/Baketa.Core/DI/Attributes/AutoRegisterAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Baketa.Core.DI.Attributes
+{
+    /// <summary>
+    /// アセンブリスキャンによる自動登録の対象となるモジュールを識別する属性。
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class AutoRegisterAttribute : Attribute
+    {
+        /// <summary>
+        /// 自動登録属性を初期化します。
+        /// </summary>
+        public AutoRegisterAttribute()
+        {
+        }
+    }
+}

--- a/Baketa.Core/DI/Attributes/ModulePriorityAttribute.cs
+++ b/Baketa.Core/DI/Attributes/ModulePriorityAttribute.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace Baketa.Core.DI.Attributes
+{
+    /// <summary>
+    /// モジュールの登録優先順位を指定する属性。
+    /// 優先順位が高いモジュールが先に登録されます。
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class ModulePriorityAttribute(ModulePriority priority) : Attribute
+    {
+        /// <summary>
+        /// モジュールの優先順位
+        /// </summary>
+        public ModulePriority Priority { get; } = priority;
+    }
+
+    /// <summary>
+    /// モジュールの優先順位を表す列挙型
+    /// </summary>
+    public enum ModulePriority
+    {
+        /// <summary>
+        /// システムコアコンポーネント（最優先）
+        /// </summary>
+        Core = 1000,
+        
+        /// <summary>
+        /// インフラストラクチャコンポーネント
+        /// </summary>
+        Infrastructure = 900,
+        
+        /// <summary>
+        /// プラットフォーム固有コンポーネント
+        /// </summary>
+        Platform = 800,
+        
+        /// <summary>
+        /// アプリケーションサービスコンポーネント
+        /// </summary>
+        Application = 700,
+        
+        /// <summary>
+        /// UIコンポーネント
+        /// </summary>
+        UI = 600,
+        
+        /// <summary>
+        /// プラグインコンポーネント
+        /// </summary>
+        Plugin = 500,
+        
+        /// <summary>
+        /// カスタムコンポーネント（最低優先度）
+        /// </summary>
+        Custom = 100
+    }
+}

--- a/Baketa.Core/DI/Exceptions/CircularDependencyException.cs
+++ b/Baketa.Core/DI/Exceptions/CircularDependencyException.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Baketa.Core.DI.Exceptions
+{
+    /// <summary>
+    /// モジュール間の循環依存が検出された場合にスローされる例外。
+    /// </summary>
+    [Serializable]
+    public class CircularDependencyException : Exception
+    {
+        /// <summary>
+        /// 循環依存の発生したモジュールパス
+        /// </summary>
+        public IReadOnlyList<Type>? DependencyCycle { get; }
+
+        /// <summary>
+        /// 新しい <see cref="CircularDependencyException"/> インスタンスを初期化します。
+        /// </summary>
+        public CircularDependencyException() : base("モジュール間の循環依存が検出されました。")
+        {
+        }
+
+        /// <summary>
+        /// 指定したエラーメッセージを使用して、新しい <see cref="CircularDependencyException"/> インスタンスを初期化します。
+        /// </summary>
+        /// <param name="message">例外の原因を説明するメッセージ</param>
+        public CircularDependencyException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// 指定したエラーメッセージと内部例外を使用して、新しい <see cref="CircularDependencyException"/> インスタンスを初期化します。
+        /// </summary>
+        /// <param name="message">例外の原因を説明するメッセージ</param>
+        /// <param name="innerException">現在の例外の原因である例外</param>
+        public CircularDependencyException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// 指定したエラーメッセージと循環依存パスを使用して、新しい <see cref="CircularDependencyException"/> インスタンスを初期化します。
+        /// </summary>
+        /// <param name="message">例外の原因を説明するメッセージ</param>
+        /// <param name="dependencyCycle">循環依存の発生したモジュールパス</param>
+        public CircularDependencyException(string message, IReadOnlyList<Type> dependencyCycle) : base(message)
+        {
+            DependencyCycle = dependencyCycle;
+        }
+
+        /// <summary>
+        /// シリアル化したデータを使用して <see cref="CircularDependencyException"/> クラスの新しいインスタンスを初期化します。
+        /// </summary>
+        /// <param name="info">例外に関するシリアル化済み情報を保持する SerializationInfo</param>
+        /// <param name="context">デシリアライズの送信元または送信先に関するコンテキスト情報</param>
+#pragma warning disable SYSLIB0051 // タイプまたはメンバーは旧形式です
+        protected CircularDependencyException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+#pragma warning restore SYSLIB0051
+    }
+}

--- a/Baketa.Core/DI/ServiceModuleBase.cs
+++ b/Baketa.Core/DI/ServiceModuleBase.cs
@@ -1,0 +1,108 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Baketa.Core.DI
+{
+    /// <summary>
+    /// サービス登録モジュールの基本実装。
+    /// 共通の依存関係解決ロジックを提供します。
+    /// </summary>
+    public abstract class ServiceModuleBase : IServiceModule
+    {
+        /// <summary>
+        /// このモジュールが提供するサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public abstract void RegisterServices(IServiceCollection services);
+
+        /// <summary>
+        /// このモジュールが依存する他のモジュールの型を取得します。
+        /// デフォルトでは依存モジュールはありません。
+        /// </summary>
+        /// <returns>依存モジュールの型のコレクション</returns>
+        public virtual IEnumerable<Type> GetDependentModules() => [];
+
+        /// <summary>
+        /// 依存するモジュールを含めて全てのモジュールを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        /// <param name="registeredModules">登録済みモジュールの集合</param>
+        /// <param name="moduleStack">現在の依存関係解決スタック（循環依存検出用）</param>
+        public void RegisterWithDependencies(
+            IServiceCollection services,
+            HashSet<Type> registeredModules,
+            Stack<Type> moduleStack)
+        {
+            var moduleType = GetType();
+            
+            // 循環依存の検出
+            if (moduleStack.Contains(moduleType))
+            {
+                var cycle = new List<Type>();
+                var found = false;
+                
+                foreach (var item in moduleStack)
+                {
+                    if (item == moduleType)
+                        found = true;
+                        
+                    if (found)
+                        cycle.Add(item);
+                }
+                
+                cycle.Add(moduleType); // 完全な循環を表示するために追加
+                
+                var cycleInfo = string.Join(" -> ", cycle.Select(t => t.Name));
+                throw new CircularDependencyException(
+                    $"モジュール間の循環依存が検出されました: {cycleInfo}", cycle);
+            }
+            
+            // このモジュールが既に登録済みの場合は何もしない
+            if (registeredModules.Contains(moduleType))
+            {
+                return;
+            }
+            
+            moduleStack.Push(moduleType);
+            
+            try
+            {
+                // 依存するモジュールを先に登録
+                foreach (var dependentModuleType in GetDependentModules())
+                {
+                    if (registeredModules.Contains(dependentModuleType))
+                    {
+                        continue; // このモジュールは既に登録済み
+                    }
+                    
+                    if (Activator.CreateInstance(dependentModuleType) is IServiceModule dependentModule)
+                    {
+                        if (dependentModule is ServiceModuleBase moduleBase)
+                        {
+                            // 依存モジュールも依存性を持つ場合は再帰的に登録
+                            moduleBase.RegisterWithDependencies(services, registeredModules, moduleStack);
+                        }
+                        else
+                        {
+                            // 通常のモジュールの場合は直接登録
+                            dependentModule.RegisterServices(services);
+                            registeredModules.Add(dependentModuleType);
+                        }
+                    }
+                }
+                
+                // このモジュールを登録
+                RegisterServices(services);
+                registeredModules.Add(moduleType);
+            }
+            finally
+            {
+                moduleStack.Pop();
+            }
+        }
+    }
+}

--- a/tests/Baketa.Core.Tests/Baketa.Core.Tests.csproj
+++ b/tests/Baketa.Core.Tests/Baketa.Core.Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Platforms>x64</Platforms>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Baketa.Core\Baketa.Core.csproj" />
+    <ProjectReference Include="..\..\Baketa.Application\Baketa.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Baketa.Core.Tests/DI/ModulePriorityTests.cs
+++ b/tests/Baketa.Core.Tests/DI/ModulePriorityTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Baketa.Core.Tests.DI
+{
+    /// <summary>
+    /// モジュール優先順位機能の単体テスト
+    /// </summary>
+    public class ModulePriorityTests
+    {
+        /// <summary>
+        /// 優先順位に基づいてモジュールが適切にソートされることをテスト
+        /// </summary>
+        [Fact]
+        public void SortModules_WithPriorities_SortsCorrectly()
+        {
+            // Arrange
+            var modules = new List<IServiceModule>
+            {
+                new UiModuleWithPriority(),
+                new CoreModuleWithPriority(),
+                new InfrastructureModuleWithPriority(),
+                new CustomModuleWithoutPriority()
+            };
+
+            // Act - 優先度でソート
+            var sortedModules = modules
+                .Select(m => new 
+                {
+                    Module = m,
+                    Priority = m.GetType().GetCustomAttribute<ModulePriorityAttribute>()?.Priority 
+                             ?? ModulePriority.Custom
+                })
+                .OrderByDescending(x => (int)x.Priority)
+                .Select(x => x.Module)
+                .ToArray();
+
+            // Assert - 期待する順序: Core, Infrastructure, UI, Custom
+            Assert.Equal(4, sortedModules.Length);
+            Assert.IsType<CoreModuleWithPriority>(sortedModules[0]);
+            Assert.IsType<InfrastructureModuleWithPriority>(sortedModules[1]);
+            Assert.IsType<UiModuleWithPriority>(sortedModules[2]);
+            Assert.IsType<CustomModuleWithoutPriority>(sortedModules[3]);
+        }
+
+        #region テスト用モジュールクラス
+
+        /// <summary>
+        /// Core優先度を持つテスト用モジュール
+        /// </summary>
+        [ModulePriority(ModulePriority.Core)]
+        private class CoreModuleWithPriority : ServiceModuleBase
+        {
+            public override void RegisterServices(IServiceCollection services)
+            {
+            }
+        }
+
+        /// <summary>
+        /// Infrastructure優先度を持つテスト用モジュール
+        /// </summary>
+        [ModulePriority(ModulePriority.Infrastructure)]
+        private class InfrastructureModuleWithPriority : ServiceModuleBase
+        {
+            public override void RegisterServices(IServiceCollection services)
+            {
+            }
+        }
+
+        /// <summary>
+        /// UI優先度を持つテスト用モジュール
+        /// </summary>
+        [ModulePriority(ModulePriority.UI)]
+        private class UiModuleWithPriority : ServiceModuleBase
+        {
+            public override void RegisterServices(IServiceCollection services)
+            {
+            }
+        }
+
+        /// <summary>
+        /// 優先度を指定していないテスト用モジュール
+        /// </summary>
+        private class CustomModuleWithoutPriority : ServiceModuleBase
+        {
+            public override void RegisterServices(IServiceCollection services)
+            {
+            }
+        }
+
+        #endregion
+    }
+}

--- a/tests/Baketa.Core.Tests/DI/ServiceModuleBaseTests.cs
+++ b/tests/Baketa.Core.Tests/DI/ServiceModuleBaseTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Baketa.Core.Tests.DI
+{
+    /// <summary>
+    /// ServiceModuleBase クラスの単体テスト
+    /// </summary>
+    public class ServiceModuleBaseTests
+    {
+        /// <summary>
+        /// 依存関係のないモジュールが正常に登録できることをテスト
+        /// </summary>
+        [Fact]
+        public void RegisterWithDependencies_WithoutDependencies_RegistersSuccessfully()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var testModule = new TestModuleWithoutDependencies();
+            var registeredModules = new HashSet<Type>();
+
+            // Act
+            testModule.RegisterWithDependencies(services, registeredModules, new Stack<Type>());
+
+            // Assert
+            Assert.Contains(typeof(TestModuleWithoutDependencies), registeredModules);
+            Assert.True(testModule.RegisterServicesCalled);
+        }
+
+        /// <summary>
+        /// 依存関係のあるモジュールが正常に登録でき、依存モジュールも登録されることをテスト
+        /// </summary>
+        [Fact]
+        public void RegisterWithDependencies_WithDependencies_RegistersAllModules()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var testModule = new TestModuleWithDependencies();
+            var registeredModules = new HashSet<Type>();
+
+            // Act
+            testModule.RegisterWithDependencies(services, registeredModules, new Stack<Type>());
+
+            // Assert
+            Assert.Contains(typeof(TestModuleWithDependencies), registeredModules);
+            Assert.Contains(typeof(TestModuleWithoutDependencies), registeredModules);
+            Assert.True(testModule.RegisterServicesCalled);
+        }
+
+        /// <summary>
+        /// 循環依存があるモジュールの場合、例外が発生することをテスト
+        /// </summary>
+        [Fact]
+        public void RegisterWithDependencies_WithCircularDependencies_ThrowsException()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var testModule = new TestModuleWithCircularDependencyA();
+            var registeredModules = new HashSet<Type>();
+
+            // Act & Assert
+            var exception = Assert.Throws<CircularDependencyException>(() => 
+                testModule.RegisterWithDependencies(services, registeredModules, new Stack<Type>()));
+
+            Assert.Contains("循環依存が検出", exception.Message);
+            Assert.NotNull(exception.DependencyCycle);
+            Assert.Contains(typeof(TestModuleWithCircularDependencyA), exception.DependencyCycle);
+            Assert.Contains(typeof(TestModuleWithCircularDependencyB), exception.DependencyCycle);
+        }
+
+        #region テスト用モジュールクラス
+
+        /// <summary>
+        /// 依存関係のないテスト用モジュール
+        /// </summary>
+        private class TestModuleWithoutDependencies : ServiceModuleBase
+        {
+            public bool RegisterServicesCalled { get; private set; }
+
+            public override void RegisterServices(IServiceCollection services)
+            {
+                RegisterServicesCalled = true;
+            }
+        }
+
+        /// <summary>
+        /// 依存関係のあるテスト用モジュール
+        /// </summary>
+        private class TestModuleWithDependencies : ServiceModuleBase
+        {
+            public bool RegisterServicesCalled { get; private set; }
+
+            public override void RegisterServices(IServiceCollection services)
+            {
+                RegisterServicesCalled = true;
+            }
+
+            public override IEnumerable<Type> GetDependentModules()
+            {
+                yield return typeof(TestModuleWithoutDependencies);
+            }
+        }
+
+        /// <summary>
+        /// 循環依存関係のあるテスト用モジュールA
+        /// </summary>
+        private class TestModuleWithCircularDependencyA : ServiceModuleBase
+        {
+            public override void RegisterServices(IServiceCollection services)
+            {
+            }
+
+            public override IEnumerable<Type> GetDependentModules()
+            {
+                yield return typeof(TestModuleWithCircularDependencyB);
+            }
+        }
+
+        /// <summary>
+        /// 循環依存関係のあるテスト用モジュールB
+        /// </summary>
+        private class TestModuleWithCircularDependencyB : ServiceModuleBase
+        {
+            public override void RegisterServices(IServiceCollection services)
+            {
+            }
+
+            public override IEnumerable<Type> GetDependentModules()
+            {
+                yield return typeof(TestModuleWithCircularDependencyA);
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
# IServiceModuleインターフェースとDI基盤の実装

このPRでは、Issue #13で定義された「IServiceModuleインターフェースの設計」を実装しました。モジュール化された依存性注入パターンを実現するための基盤を提供します。

## 実装した機能

### 1. IServiceModuleインターフェース
- サービス登録のための基本インターフェース
- デフォルト実装を含む依存モジュール取得メソッド

### 2. モジュール優先順位機能
- ModulePriorityAttribute属性の実装
- レイヤー別優先順位を定義する列挙型（Core/Infrastructure/Application/UI等）

### 3. 依存関係管理の仕組み
- 依存モジュールの解決ロジック
- 循環依存検出と明確なエラーメッセージ提供

### 4. モジュールの検出機能
- 手動登録を基本とした明示的なモジュール管理
- AutoRegisterAttribute属性を用いたオプショナルな自動検出機能

### 5. サービスコレクション拡張メソッド
- AddBaketaServices拡張メソッドによる簡単な登録
- 優先順位に基づいたモジュール登録順序の制御

## テスト

テストプロジェクト `Baketa.Core.Tests` に以下のテストを追加しました：
- 依存関係解決の正常ケース
- 循環依存検出
- モジュール優先順位ソート

## 注意点

- Microsoft.Extensions.DependencyInjection パッケージはバージョン 8.0.0 を使用しています
- レイヤー別の実際のモジュール実装は今後のIssue #14で行います
- DIコンテナと実際のアプリケーションの統合はIssue #15で対応します

## 関連Issue

- Issue #13: 実装: IServiceModuleインターフェースの設計
- Issue #14: 実装: レイヤー別モジュールの実装 (今後の予定)
- Issue #15: 実装: 拡張メソッドとDIコンテナ統合 (今後の予定)

