### PR TITLE
feat: レイヤー別DIモジュールの実装 (#14)

### DIFF
--- a/Baketa.Application/DI/Extensions/ModuleRegistration.cs
+++ b/Baketa.Application/DI/Extensions/ModuleRegistration.cs
@@ -1,0 +1,80 @@
+using Baketa.Application.DI.Modules;
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI.Modules;
+using Baketa.Infrastructure.Platform.DI.Modules;
+//using Baketa.UI.DI.Modules; // UIモジュールは現在実装中
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Baketa.Application.DI.Extensions
+{
+    /// <summary>
+    /// Baketaの標準モジュールを登録するための拡張メソッドを提供します。
+    /// </summary>
+    public static class ModuleRegistration
+    {
+        /// <summary>
+        /// Baketaの標準モジュールを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        /// <param name="scanForModules">オプショナルなモジュールを自動スキャンするかどうか</param>
+        /// <returns>サービスコレクション</returns>
+        public static IServiceCollection AddBaketaModules(
+            this IServiceCollection services,
+            bool scanForModules = false)
+        {
+            // 標準モジュールのインスタンスを作成
+            var standardModules = new IServiceModule[]
+            {
+                new CoreModule(),              // コアレイヤー
+                // new InfrastructureModule(),    // インフラストラクチャレイヤー (現時点では実装済みのモジュールのみ含める)
+                new PlatformModule(),          // プラットフォーム依存レイヤー
+                new ApplicationModule(),       // アプリケーションレイヤー
+                // new UIModule()                 // UIレイヤー (現時点では実装済みのモジュールのみ含める)
+            };
+            
+            // ServiceCollectionExtensions.AddBaketaServicesを使用して登録
+            return services.AddBaketaServices(scanForModules, standardModules);
+        }
+        
+        /// <summary>
+        /// Baketa.Coreのモジュールのみを登録します。
+        /// テスト用やヘッドレス実行に便利です。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        /// <returns>サービスコレクション</returns>
+        public static IServiceCollection AddBaketaCoreModules(this IServiceCollection services)
+        {
+            return services.AddBaketaServices(false, new CoreModule());
+        }
+        
+        /// <summary>
+        /// Baketa.Infrastructureとそれまでのモジュールのみを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        /// <returns>サービスコレクション</returns>
+        public static IServiceCollection AddBaketaInfrastructureModules(this IServiceCollection services)
+        {
+            return services.AddBaketaServices(
+                false, 
+                new CoreModule());
+                // Infrastructureモジュールは現在実装中
+        }
+        
+        /// <summary>
+        /// Baketa.Applicationとそれまでのモジュールのみを登録します。
+        /// UI要素を含まないバージョンに便利です。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        /// <returns>サービスコレクション</returns>
+        public static IServiceCollection AddBaketaApplicationModules(this IServiceCollection services)
+        {
+            return services.AddBaketaServices(
+                false, 
+                new CoreModule(),
+                // new InfrastructureModule(), 現在実装中
+                new PlatformModule(),
+                new ApplicationModule());
+        }
+    }
+}

--- a/Baketa.Application/DI/Modules/ApplicationModule.cs
+++ b/Baketa.Application/DI/Modules/ApplicationModule.cs
@@ -1,0 +1,97 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Baketa.Core.DI.Modules;
+using Baketa.Infrastructure.Platform.DI.Modules;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Baketa.Application.DI.Modules
+{
+    /// <summary>
+    /// アプリケーションレイヤーのサービスを登録するモジュール。
+    /// ビジネスロジックやユースケースの実装が含まれます。
+    /// </summary>
+    [ModulePriority(ModulePriority.Application)]
+    public class ApplicationModule : ServiceModuleBase
+    {
+        /// <summary>
+        /// アプリケーションサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public override void RegisterServices(IServiceCollection services)
+        {
+            // OCRアプリケーションサービス
+            RegisterOcrApplicationServices(services);
+            
+            // 翻訳アプリケーションサービス
+            RegisterTranslationApplicationServices(services);
+            
+            // その他のアプリケーションサービス
+            RegisterOtherApplicationServices(services);
+            
+            // イベントハンドラー
+            RegisterEventHandlers(services);
+        }
+
+        /// <summary>
+        /// OCRアプリケーションサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterOcrApplicationServices(IServiceCollection services)
+        {
+            // OCR関連のアプリケーションサービス
+            // 例: services.AddSingleton<IOcrService, OcrService>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// 翻訳アプリケーションサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterTranslationApplicationServices(IServiceCollection services)
+        {
+            // 翻訳関連のアプリケーションサービス
+            // 例: services.AddSingleton<ITranslationService, TranslationService>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// その他のアプリケーションサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterOtherApplicationServices(IServiceCollection services)
+        {
+            // キャプチャサービスなど他のアプリケーションサービス
+            // 例: services.AddSingleton<ICaptureService, CaptureService>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// イベントハンドラーを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterEventHandlers(IServiceCollection services)
+        {
+            // 各種イベントハンドラーの登録
+            // 例: services.AddSingleton<ICaptureCompletedEventHandler, CaptureCompletedEventHandler>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// このモジュールが依存する他のモジュールの型を取得します。
+        /// </summary>
+        /// <returns>依存モジュールの型のコレクション</returns>
+        public override IEnumerable<Type> GetDependentModules()
+        {
+            yield return typeof(CoreModule);
+            yield return typeof(PlatformModule);
+            // 現時点ではInfrastructureModuleは参照できない
+        }
+    }
+}

--- a/Baketa.Core/DI/Modules/CoreModule.cs
+++ b/Baketa.Core/DI/Modules/CoreModule.cs
@@ -1,0 +1,68 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Baketa.Core.DI.Modules
+{
+    /// <summary>
+    /// コアレイヤーのサービスを登録するモジュール。
+    /// 最も基本的なサービスとインターフェースが含まれます。
+    /// </summary>
+    [ModulePriority(ModulePriority.Core)]
+    public class CoreModule : ServiceModuleBase
+    {
+        /// <summary>
+        /// コアサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public override void RegisterServices(IServiceCollection services)
+        {
+            // コアインターフェースと抽象化の登録
+            RegisterAbstractions(services);
+            
+            // イベント集約システム
+            RegisterEventAggregator(services);
+            
+            // その他のコアサービス
+            RegisterCoreServices(services);
+        }
+
+        /// <summary>
+        /// コアの抽象化（インターフェース）を登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterAbstractions(IServiceCollection services)
+        {
+            // ファクトリーやインターフェースの登録
+            // 例: services.AddSingleton<IImageFactory, DefaultImageFactory>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// イベント集約システムを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterEventAggregator(IServiceCollection services)
+        {
+            // イベント集約システムの登録
+            // 例: services.AddSingleton<IEventAggregator, EventAggregator>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// その他のコアサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterCoreServices(IServiceCollection services)
+        {
+            // ロギングサービスやその他の基本サービス
+            // 例: services.AddSingleton<ISettingsManager, SettingsManager>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+    }
+}

--- a/Baketa.Infrastructure.Platform/DI/Modules/PlatformModule.cs
+++ b/Baketa.Infrastructure.Platform/DI/Modules/PlatformModule.cs
@@ -1,0 +1,89 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Baketa.Core.DI.Modules;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Baketa.Infrastructure.Platform.DI.Modules
+{
+    /// <summary>
+    /// プラットフォーム固有のサービスを登録するモジュール。
+    /// Windowsプラットフォーム固有の実装が含まれます。
+    /// </summary>
+    [ModulePriority(ModulePriority.Platform)]
+    public class PlatformModule : ServiceModuleBase
+    {
+        /// <summary>
+        /// プラットフォーム固有サービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public override void RegisterServices(IServiceCollection services)
+        {
+            // Windowsプラットフォーム固有の実装を登録
+            if (OperatingSystem.IsWindows())
+            {
+                // キャプチャサービス
+                RegisterCaptureServices(services);
+                
+                // 画像処理サービス
+                RegisterImageServices(services);
+                
+                // その他のWindows固有サービス
+                RegisterWindowsServices(services);
+            }
+            else
+            {
+                // 現在はWindows専用
+                Console.WriteLine("警告: Baketaは現在Windowsプラットフォームのみをサポートしています。");
+            }
+        }
+
+        /// <summary>
+        /// キャプチャ関連サービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterCaptureServices(IServiceCollection services)
+        {
+            // スクリーンキャプチャなどの登録
+            // 例: services.AddSingleton<IWindowsCaptureService, WindowsCaptureService>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// 画像処理サービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterImageServices(IServiceCollection services)
+        {
+            // Windows画像処理関連の登録
+            // 例: services.AddSingleton<IWindowsImageFactory, WindowsImageFactory>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// その他のWindows固有サービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterWindowsServices(IServiceCollection services)
+        {
+            // その他のWindows API関連サービス
+            // 例: services.AddSingleton<IWindowsOverlayService, WindowsOverlayService>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// このモジュールが依存する他のモジュールの型を取得します。
+        /// </summary>
+        /// <returns>依存モジュールの型のコレクション</returns>
+        public override IEnumerable<Type> GetDependentModules()
+        {
+            yield return typeof(CoreModule);
+            // InfrastructureModuleはまだ使用できないため、直接CoreModuleに依存
+        }
+    }
+}

--- a/Baketa.Infrastructure/DI/Modules/InfrastructureModule.cs
+++ b/Baketa.Infrastructure/DI/Modules/InfrastructureModule.cs
@@ -1,0 +1,79 @@
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Baketa.Core.DI.Modules;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Baketa.Infrastructure.DI.Modules
+{
+    /// <summary>
+    /// インフラストラクチャレイヤーのサービスを登録するモジュール。
+    /// 外部サービス連携やプラットフォーム非依存の実装が含まれます。
+    /// </summary>
+    [ModulePriority(ModulePriority.Infrastructure)]
+    public class InfrastructureModule : ServiceModuleBase
+    {
+        /// <summary>
+        /// インフラストラクチャサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public override void RegisterServices(IServiceCollection services)
+        {
+            // OCR関連サービス
+            RegisterOcrServices(services);
+            
+            // 翻訳サービス
+            RegisterTranslationServices(services);
+            
+            // データ永続化
+            RegisterPersistenceServices(services);
+        }
+
+        /// <summary>
+        /// OCR関連サービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterOcrServices(IServiceCollection services)
+        {
+            // OCRエンジンやプロセッサーの登録
+            // 例: services.AddSingleton<IOcrEngine, PaddleOcrEngine>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// 翻訳サービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterTranslationServices(IServiceCollection services)
+        {
+            // 翻訳エンジンやサービスの登録
+            // 例: services.AddSingleton<ITranslationEngine, OnnxTranslationEngine>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// データ永続化サービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterPersistenceServices(IServiceCollection services)
+        {
+            // 設定保存やキャッシュサービスの登録
+            // 例: services.AddSingleton<ISettingsStorage, JsonSettingsStorage>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// このモジュールが依存する他のモジュールの型を取得します。
+        /// </summary>
+        /// <returns>依存モジュールの型のコレクション</returns>
+        public override IEnumerable<Type> GetDependentModules()
+        {
+            yield return typeof(CoreModule);
+        }
+    }
+}

--- a/Baketa.UI/DI/Modules/UIModule.cs
+++ b/Baketa.UI/DI/Modules/UIModule.cs
@@ -1,0 +1,83 @@
+using Baketa.Application.DI.Modules;
+using Baketa.Core.Abstractions.DI;
+using Baketa.Core.DI;
+using Baketa.Core.DI.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Baketa.UI.DI.Modules
+{
+    /// <summary>
+    /// UIレイヤーのサービスを登録するモジュール。
+    /// ViewModelやUI関連サービスの実装が含まれます。
+    /// </summary>
+    [ModulePriority(ModulePriority.UI)]
+    public class UIModule : ServiceModuleBase
+    {
+        /// <summary>
+        /// UIサービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        public override void RegisterServices(IServiceCollection services)
+        {
+            // ViewModelの登録
+            RegisterViewModels(services);
+            
+            // UI関連サービスの登録
+            RegisterUIServices(services);
+            
+            // 設定系UIの登録
+            RegisterSettingsUI(services);
+        }
+
+        /// <summary>
+        /// ViewModelを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterViewModels(IServiceCollection services)
+        {
+            // メインViewModelとオーバーレイViewModel
+            // 例: services.AddSingleton<MainViewModel>();
+            // 例: services.AddSingleton<OverlayViewModel>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// UI関連サービスを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterUIServices(IServiceCollection services)
+        {
+            // ダイアログサービスやナビゲーションサービス
+            // 例: services.AddSingleton<IDialogService, AvaloniaDialogService>();
+            // 例: services.AddSingleton<INotificationService, AvaloniaNotificationService>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// 設定系UIを登録します。
+        /// </summary>
+        /// <param name="services">サービスコレクション</param>
+        private void RegisterSettingsUI(IServiceCollection services)
+        {
+            // 設定ViewModelと関連サービス
+            // 例: services.AddTransient<SettingsViewModel>();
+            // 例: services.AddTransient<ProfileEditorViewModel>();
+            
+            // 現時点では実際の実装はプレースホルダー
+        }
+        
+        /// <summary>
+        /// このモジュールが依存する他のモジュールの型を取得します。
+        /// </summary>
+        /// <returns>依存モジュールの型のコレクション</returns>
+        public override IEnumerable<Type> GetDependentModules()
+        {
+            yield return typeof(ApplicationModule);
+            // 他のモジュールはApplicationModuleを通じて間接的に依存
+        }
+    }
+}

--- a/Baketa.UI/Program.cs.example
+++ b/Baketa.UI/Program.cs.example
@@ -1,0 +1,130 @@
+using Baketa.Application.DI.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Baketa.UI
+{
+    public static class Program
+    {
+        // アプリケーションのエントリーポイント
+        [STAThread]
+        public static void Main(string[] args)
+        {
+            var services = new ServiceCollection();
+            
+            // 環境に基づいて適切なサービスを登録
+            ConfigureServices(services, GetEnvironment(args));
+            
+            // サービスプロバイダーの構築
+            var serviceProvider = services.BuildServiceProvider();
+            
+            // アプリケーションの実行
+            using (var app = serviceProvider.GetRequiredService<App>())
+            {
+                app.Run();
+            }
+        }
+        
+        // 環境に基づいてサービスを設定
+        private static void ConfigureServices(IServiceCollection services, string environment)
+        {
+            // ロギングの設定
+            ConfigureLogging(services, environment);
+            
+            // アプリケーションのメインクラスを登録
+            services.AddSingleton<App>();
+            
+            // 環境に基づいてモジュールを登録
+            switch (environment.ToLower())
+            {
+                case "development":
+                    // 開発環境設定
+                    services.AddBaketaModules(scanForModules: true);
+                    services.AddDevelopmentServices();
+                    break;
+                    
+                case "test":
+                    // テスト環境設定
+                    services.AddBaketaApplicationModules();
+                    services.AddTestServices();
+                    break;
+                    
+                case "production":
+                default:
+                    // 本番環境設定
+                    services.AddBaketaModules(scanForModules: false);
+                    services.AddProductionServices();
+                    break;
+            }
+        }
+        
+        // ロギングの設定
+        private static void ConfigureLogging(IServiceCollection services, string environment)
+        {
+            services.AddLogging(builder =>
+            {
+                builder.AddConsole();
+                
+                if (environment.ToLower() == "development")
+                {
+                    builder.SetMinimumLevel(LogLevel.Debug);
+                }
+                else
+                {
+                    builder.SetMinimumLevel(LogLevel.Information);
+                }
+                
+                // ファイルロガーの追加（必要に応じて）
+                // builder.AddFile("logs/baketa-{Date}.log");
+            });
+        }
+        
+        // コマンドライン引数から環境を取得
+        private static string GetEnvironment(string[] args)
+        {
+            // コマンドライン引数から環境を検索
+            foreach (var arg in args)
+            {
+                if (arg.StartsWith("--environment=", StringComparison.OrdinalIgnoreCase))
+                {
+                    return arg.Substring("--environment=".Length);
+                }
+            }
+            
+            // 環境変数から環境を取得
+            var env = Environment.GetEnvironmentVariable("BAKETA_ENVIRONMENT");
+            if (!string.IsNullOrEmpty(env))
+            {
+                return env;
+            }
+            
+            // デフォルト環境
+            return "production";
+        }
+        
+        // 開発環境特有のサービスを追加
+        private static IServiceCollection AddDevelopmentServices(this IServiceCollection services)
+        {
+            // 開発環境特有のサービスを登録
+            // 例: services.AddSingleton<IDeveloperTools, DeveloperToolsImplementation>();
+            return services;
+        }
+        
+        // テスト環境特有のサービスを追加
+        private static IServiceCollection AddTestServices(this IServiceCollection services)
+        {
+            // テスト環境特有のサービスを登録
+            // 例: services.AddSingleton<ITestingHelper, TestingHelperImplementation>();
+            return services;
+        }
+        
+        // 本番環境特有のサービスを追加
+        private static IServiceCollection AddProductionServices(this IServiceCollection services)
+        {
+            // 本番環境特有のサービスを登録
+            // 例: services.AddSingleton<ITelemetry, TelemetryImplementation>();
+            return services;
+        }
+    }
+}

--- a/tests/Baketa.Application.Tests/Baketa.Application.Tests.csproj
+++ b/tests/Baketa.Application.Tests/Baketa.Application.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Platforms>x64</Platforms>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Baketa.Core\Baketa.Core.csproj" />
+    <ProjectReference Include="..\..\Baketa.Infrastructure\Baketa.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Baketa.Infrastructure.Platform\Baketa.Infrastructure.Platform.csproj" />
+    <ProjectReference Include="..\..\Baketa.Application\Baketa.Application.csproj" />
+    <ProjectReference Include="..\..\Baketa.UI\Baketa.UI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Baketa.Application.Tests/DI/ModuleRegistrationTests.cs
+++ b/tests/Baketa.Application.Tests/DI/ModuleRegistrationTests.cs
@@ -1,0 +1,102 @@
+using Baketa.Application.DI.Extensions;
+using Baketa.Core.Abstractions.DI;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Baketa.Application.Tests.DI
+{
+    /// <summary>
+    /// モジュール登録の単体テスト
+    /// </summary>
+    public class ModuleRegistrationTests
+    {
+        /// <summary>
+        /// AddBaketaModulesでコア依存関係が正常に登録されることをテスト
+        /// </summary>
+        [Fact]
+        public void AddBaketaModules_RegistersAllModules()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            services.AddBaketaModules();
+            var provider = services.BuildServiceProvider();
+            
+            // ここでは実装が存在しないため、特定のサービスの存在をアサートできません
+            // したがって、RegisterServicesが例外を投げずに実行されたことをテスト
+            
+            // Assert
+            // 例外が発生しなければテスト成功
+            // 実際の実装では具体的なサービスの登録をアサートするテストを追加すべき
+        }
+        
+        /// <summary>
+        /// AddBaketaCoreModulesがコアモジュールのみを登録することをテスト
+        /// </summary>
+        [Fact]
+        public void AddBaketaCoreModules_RegistersOnlyCoreModule()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            services.AddBaketaCoreModules();
+            
+            // Assert
+            // 実際の実装では、コアモジュールのサービスのみが登録されていることを確認するテストを追加
+        }
+        
+        /// <summary>
+        /// AddBaketaInfrastructureModulesが適切なモジュールを登録することをテスト
+        /// </summary>
+        [Fact]
+        public void AddBaketaInfrastructureModules_RegistersCoreAndInfrastructureModules()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            services.AddBaketaInfrastructureModules();
+            
+            // Assert
+            // 実際の実装では、CoreとInfrastructureモジュールのサービスが登録されていることを確認するテストを追加
+        }
+        
+        /// <summary>
+        /// AddBaketaApplicationModulesが適切なモジュールを登録することをテスト
+        /// </summary>
+        [Fact]
+        public void AddBaketaApplicationModules_RegistersAllExceptUIModules()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act
+            services.AddBaketaApplicationModules();
+            
+            // Assert
+            // 実際の実装では、UI以外のすべてのモジュールのサービスが登録されていることを確認するテストを追加
+        }
+        
+        /// <summary>
+        /// モジュールの優先順位が適切に考慮されることをテスト
+        /// </summary>
+        [Fact]
+        public void ModuleRegistration_ConsidersModulePriorities()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act - 登録追跡のためにリスナーを追加
+            var registrationOrder = new System.Collections.Generic.List<string>();
+            
+            // モックモジュールの作成とリスナーの追加は実際のテストで実装
+            
+            // Assert
+            // 実際の実装では、モジュールが優先順位に従って登録されることを確認
+        }
+    }
+}


### PR DESCRIPTION
# レイヤー別DIモジュールの実装

このPRでは、Issue #14で定義された「レイヤー別モジュールの実装」を実現しました。各レイヤー（Core、Platform、Application）のDIモジュールを実装し、アプリケーションのレイヤー構造を反映したサービス登録の仕組みを提供します。

## 実装した機能

### 1. CoreModule
- コアインターフェースと抽象化の登録機能
- イベント集約システムの登録
- その他のコアサービス登録用のメソッド構造

### 2. PlatformModule
- Windowsプラットフォーム固有のサービス登録
- 画像処理とキャプチャサービスの登録
- OSの検出と適切な処理（現在はWindows専用）

### 3. ApplicationModule
- OCRアプリケーションサービスの登録
- 翻訳アプリケーションサービスの登録
- イベントハンドラーの登録

### 4. モジュール統合
- ModuleRegistration拡張メソッドの実装
- レイヤー別登録のためのヘルパーメソッド
- 環境ごとの設定例（Program.cs.example）

## 実装上の注意点

- 現段階では、実装可能なレイヤー（Core、Platform、Application）のモジュールのみを実装
- InfrastructureModuleとUIModuleは今後の実装に備えて準備
- モジュール間の依存関係をGetDependentModules()で明確に定義
- 優先順位を各モジュールに設定（ModulePriority属性）

## 次のステップ

- Issue #15「拡張メソッドとDIコンテナ統合」への移行
- 実際のサービス実装に合わせたモジュール登録の更新
- InfrastructureModuleとUIModuleの完全実装

## 関連Issue

- Issue #13: 実装: IServiceModuleインターフェースの設計 (完了)
- Issue #14: 実装: レイヤー別モジュールの実装 (本PR)
- Issue #15: 実装: 拡張メソッドとDIコンテナ統合 (今後の予定)
