### PR TITLE
feat(download): Issue #210 GPU対応Surya OCRサーバーダウンロード機能

### DIFF
--- a/Baketa.Core/Abstractions/Services/IComponentDownloader.cs
+++ b/Baketa.Core/Abstractions/Services/IComponentDownloader.cs
@@ -59,6 +59,9 @@ public interface IComponentDownloader
 /// <param name="ExpectedSizeBytes">Expected file size in bytes (for progress display)</param>
 /// <param name="Checksum">Optional SHA256 checksum for verification</param>
 /// <param name="IsRequired">Whether this component is required for app to function</param>
+/// <param name="SplitParts">[Issue #210] Number of split parts (> 1 for files exceeding GitHub's 2GB limit)</param>
+/// <param name="PartChecksums">[Issue #210] SHA256 checksums for each split part (for early failure detection)</param>
+/// <param name="SplitPartSuffixFormat">[Issue #210] Format string for split part suffix</param>
 public record ComponentInfo(
     string Id,
     string DisplayName,
@@ -66,7 +69,10 @@ public record ComponentInfo(
     string LocalPath,
     long ExpectedSizeBytes,
     string? Checksum = null,
-    bool IsRequired = true);
+    bool IsRequired = true,
+    int SplitParts = 1,
+    IReadOnlyList<string>? PartChecksums = null,
+    string SplitPartSuffixFormat = ".{0:D3}");
 
 /// <summary>
 /// Download progress event arguments

--- a/Baketa.Infrastructure/DI/Modules/InfrastructureModule.cs
+++ b/Baketa.Infrastructure/DI/Modules/InfrastructureModule.cs
@@ -1214,8 +1214,12 @@ public class InfrastructureModule : ServiceModuleBase
                 logger.LogWarning("[Issue185] Components配列が空です！appsettings.jsonを確認してください");
             }
 
+            // [Issue #210] GPU検出器を取得（オプショナル - 登録されていない場合はnull）
+            var gpuDetector = provider.GetService<Baketa.Core.Abstractions.GPU.IGpuEnvironmentDetector>();
+            logger.LogDebug("[Issue #210] GPU detector: {Status}", gpuDetector != null ? "Available" : "Not available");
+
             logger.LogDebug("[Issue185] ComponentDownloadService インスタンス作成 - Singleton");
-            return new ComponentDownloadService(logger, httpClient, settings);
+            return new ComponentDownloadService(logger, httpClient, settings, gpuDetector);
         });
 
         // 設定値のログ出力はファクトリー内のILoggerで実行されます

--- a/Baketa.UI/appsettings.json
+++ b/Baketa.UI/appsettings.json
@@ -434,11 +434,15 @@
       {
         "Id": "surya_ocr_server",
         "DisplayName": "Surya OCR Server",
-        "FileName": "BaketaSuryaOcrServer.zip",
+        "FileName": "BaketaSuryaOcrServer-cpu.zip",
+        "CudaFileName": "BaketaSuryaOcrServer-cuda.zip",
         "LocalSubPath": "grpc_server\\BaketaSuryaOcrServer",
         "UseAppData": false,
-        "ExpectedSizeBytes": 180000000,
+        "ExpectedSizeBytes": 226000000,
+        "CudaExpectedSizeBytes": 2550000000,
         "Checksum": null,
+        "CudaChecksum": null,
+        "CudaSplitParts": 2,
         "IsRequired": true,
         "VerificationFile": "BaketaSuryaOcrServer.exe"
       },

--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -189,16 +189,9 @@ if (Test-Path $translationServerDir) {
     Write-Host "  WARNING: BaketaTranslationServer not found" -ForegroundColor Red
 }
 
-# 5.2.1 Copy BaketaSuryaOcrServer.exe
-$suryaServerDir = "$ProjectRoot\grpc_server\dist\BaketaSuryaOcrServer"
-if (Test-Path $suryaServerDir) {
-    $targetDir = "$OutputDir\grpc_server\BaketaSuryaOcrServer"
-    $null = New-Item -ItemType Directory -Path $targetDir -Force
-    Write-Host "  Copying BaketaSuryaOcrServer..." -ForegroundColor Gray
-    Copy-Item -Path "$suryaServerDir\*" -Destination $targetDir -Recurse
-} else {
-    Write-Host "  WARNING: BaketaSuryaOcrServer not found" -ForegroundColor Red
-}
+# 5.2.1 BaketaSuryaOcrServer - [Issue #210] 初回起動時にGPU検出結果に基づきダウンロード
+# CPU版/CUDA版はGitHub Releasesから自動ダウンロードされるため、リリースパッケージには含めない
+Write-Host "  BaketaSuryaOcrServer: Skipped (downloaded on first run based on GPU detection)" -ForegroundColor Gray
 
 # 5.3 Copy OCR models (ppocrv5-onnx)
 $ocrModelDir = "$ProjectRoot\Models\ppocrv5-onnx"


### PR DESCRIPTION
## Summary
- GPU検出によるCUDA/CPU版Surya OCRサーバーの自動選択機能を実装
- GitHub Releases 2GB制限対応の分割ファイルダウンロード・結合機能を追加
- Gemini 2.5 PROコードレビューで指摘された改善点を全て対応

## 変更内容

### 新機能
- **GPU自動検出**: IGpuEnvironmentDetectorによるCUDA対応判定
- **分割ダウンロード**: 2GB超ファイルを複数パートに分割してダウンロード・結合
- **パート単位チェックサム**: 各パートダウンロード直後に検証（早期失敗検出）
- **リアルタイム進捗**: 500ms間隔でパーセンテージ・速度表示

### 改善
- 分割ファイル用ディスク容量チェック（一時領域2倍確保）
- 設定検証強化（CudaPartChecksums数、SplitPartSuffixFormat形式）
- ダウンロードロジック共通化（重複メソッド削除、38行削減）

### 設定
```json
{
  "Id": "surya_ocr_server",
  "FileName": "BaketaSuryaOcrServer-cpu.zip",
  "CudaFileName": "BaketaSuryaOcrServer-cuda.zip",
  "CudaSplitParts": 2,
  "ExpectedSizeBytes": 226000000,
  "CudaExpectedSizeBytes": 2550000000
}
```

## Test plan
- [x] GPU環境でCUDA版が自動選択されることを確認
- [x] 分割ファイル（2パート、計2.4GB）のダウンロード・結合を確認
- [x] `torch.cuda.is_available()=True`でGPUモード起動を確認
- [x] ビルド成功（0エラー、0警告）

## 関連Issue
Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)