### PR TITLE
fix: HealthMonitorのサーバー再起動をPythonServerManagerに委譲

### DIFF
--- a/Baketa.Core/Abstractions/Translation/IPythonServerManager.cs
+++ b/Baketa.Core/Abstractions/Translation/IPythonServerManager.cs
@@ -70,4 +70,12 @@ public interface IPythonServerManager : IDisposable, IAsyncDisposable
     /// ヘルスチェックタイマーを初期化します
     /// </summary>
     void InitializeHealthCheckTimer();
+
+    /// <summary>
+    /// サーバーを再起動します（停止→起動）
+    /// HealthMonitorからの委譲用
+    /// </summary>
+    /// <param name="languagePair">言語ペア（例: "ja-en"）</param>
+    /// <returns>再起動成功時はサーバー情報、失敗時はnull</returns>
+    Task<IPythonServerInfo?> RestartServerAsync(string languagePair);
 }

--- a/Baketa.Infrastructure/Translation/Services/PythonServerManager.cs
+++ b/Baketa.Infrastructure/Translation/Services/PythonServerManager.cs
@@ -268,6 +268,34 @@ public class PythonServerManager(
         await PerformHealthCheckInternalAsync().ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
+    public async Task<IPythonServerInfo?> RestartServerAsync(string languagePair)
+    {
+        logger.LogInformation("🔄 [RESTART] サーバー再起動開始: {LanguagePair}", languagePair);
+
+        try
+        {
+            // 1. 既存サーバーを停止
+            await StopServerAsync(languagePair).ConfigureAwait(false);
+
+            // プロセス終了待機（安全マージン）
+            await Task.Delay(2000).ConfigureAwait(false);
+
+            // 2. 新しいサーバーを起動
+            var serverInfo = await StartServerAsync(languagePair).ConfigureAwait(false);
+
+            logger.LogInformation("✅ [RESTART] サーバー再起動成功: {LanguagePair} → Port {Port}",
+                languagePair, serverInfo.Port);
+
+            return serverInfo;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "❌ [RESTART] サーバー再起動失敗: {LanguagePair}", languagePair);
+            return null;
+        }
+    }
+
     /// <summary>
     /// Pythonプロセス起動
     /// </summary>


### PR DESCRIPTION
## Summary
- 配布版でPythonがインストールされていない環境で、HealthMonitorが直接`py`コマンドを呼び出して失敗する問題を修正
- HealthMonitorのサーバー再起動ロジックをPythonServerManagerに委譲するパターンを実装
- 開発版/配布版で同じコードパスを通るため、開発中に配布版の問題を検出可能に

## Changes
- `IPythonServerManager`: `RestartServerAsync()`メソッドを追加
- `PythonServerManager`: Stop→Startの再起動ロジックを実装
- `PythonServerHealthMonitor`: サーバー再起動をPythonServerManagerに委譲

## Test plan
- [x] ビルド成功確認
- [x] 開発版でアプリ起動・HealthMonitor動作確認
- [x] ログで`[DELEGATE_RESTART] PythonServerManagerに再起動を委譲`が出力されることを確認
- [x] サーバー再起動が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)