### PR TITLE
fix: gRPCサーバーのバインドアドレスを127.0.0.1に変更

### DIFF
--- a/grpc_server/README.md
+++ b/grpc_server/README.md
@@ -93,7 +93,7 @@ python start_server.py --use-ctranslate2
 ```
 
 **CTranslate2エンジン設定**:
-- ホスト: `0.0.0.0` (全インターフェース)
+- ホスト: `127.0.0.1` (localhost only、ファイアウォールダイアログ回避)
 - ポート: `50051`
 - モデル: `../models/nllb-200-ct2` (int8量子化、610MB)
 - デバイス: GPU利用可能ならCUDA、なければCPU
@@ -107,7 +107,7 @@ python start_server.py
 ```
 
 **NllbEngine設定**:
-- ホスト: `0.0.0.0` (全インターフェース)
+- ホスト: `127.0.0.1` (localhost only、ファイアウォールダイアログ回避)
 - ポート: `50051`
 - モデル: `facebook/nllb-200-distilled-600M` (transformers、2.4GB)
 - デバイス: GPU利用可能ならCUDA、なければCPU
@@ -140,7 +140,7 @@ python start_server.py --debug
 
 ```
 ================================================================================
-gRPC Translation Server is running on 0.0.0.0:50051
+gRPC Translation Server is running on 127.0.0.1:50051
    Engine: CTranslate2Engine
    Model: CTranslate2 (int8)
    Device: cuda
@@ -153,7 +153,7 @@ Press Ctrl+C to stop the server
 
 ```
 ================================================================================
-gRPC Translation Server is running on 0.0.0.0:50051
+gRPC Translation Server is running on 127.0.0.1:50051
    Engine: NllbEngine
    Model: facebook/nllb-200-distilled-600M
    Device: cuda

--- a/grpc_server/ocr_server_hybrid.py
+++ b/grpc_server/ocr_server_hybrid.py
@@ -426,7 +426,8 @@ def serve(port: int = 50052, device: str = "cuda", onnx_model_path: Optional[str
             OcrServiceServicer(engine), server
         )
 
-    server.add_insecure_port(f'[::]:{port}')
+    # localhost only - Windowsファイアウォールダイアログを回避
+    server.add_insecure_port(f'127.0.0.1:{port}')
     server.start()
 
     logger.info(f"Hybrid OCR gRPCサーバー起動 (port: {port})")

--- a/grpc_server/ocr_server_paddlevl.py
+++ b/grpc_server/ocr_server_paddlevl.py
@@ -352,7 +352,8 @@ def serve(port: int = 50053, device: str = "cuda"):
             OcrServiceServicer(engine), server
         )
 
-    server.add_insecure_port(f'[::]:{port}')
+    # localhost only - Windowsファイアウォールダイアログを回避
+    server.add_insecure_port(f'127.0.0.1:{port}')
     server.start()
 
     logger.info(f"PaddleOCR-VL gRPCサーバー起動 (port: {port})")

--- a/grpc_server/ocr_server_surya.py
+++ b/grpc_server/ocr_server_surya.py
@@ -438,7 +438,8 @@ def serve(port: int = 50052, device: str = "cuda", use_quantized: bool = False):
             OcrServiceServicer(engine), server
         )
 
-    server.add_insecure_port(f'[::]:{port}')
+    # localhost only - Windowsファイアウォールダイアログを回避
+    server.add_insecure_port(f'127.0.0.1:{port}')
     server.start()
 
     logger.info(f"Surya OCR gRPCサーバー起動 (port: {port})")

--- a/grpc_server/ocr_server_surya_onnx.py
+++ b/grpc_server/ocr_server_surya_onnx.py
@@ -386,7 +386,8 @@ def serve(port: int = 50052, model_path: Optional[str] = None, use_gpu: bool = T
             OcrServiceServicer(engine), server
         )
 
-    server.add_insecure_port(f'[::]:{port}')
+    # localhost only - Windowsファイアウォールダイアログを回避
+    server.add_insecure_port(f'127.0.0.1:{port}')
     server.start()
 
     logger.info(f"Surya OCR (ONNX) gRPCサーバー起動 (port: {port})")

--- a/grpc_server/start_server.py
+++ b/grpc_server/start_server.py
@@ -381,8 +381,8 @@ def main():
     parser.add_argument(
         "--host",
         type=str,
-        default="0.0.0.0",
-        help="gRPC server host (default: 0.0.0.0 for all interfaces)"
+        default="127.0.0.1",
+        help="gRPC server host (default: 127.0.0.1 for localhost only, use 0.0.0.0 for all interfaces)"
     )
     parser.add_argument(
         "--debug",


### PR DESCRIPTION
## Summary
- Windows Firewallダイアログ（「このアプリの通信を許可しますか？」）を回避するため、全gRPCサーバーのバインドアドレスを`0.0.0.0`/`[::]`から`127.0.0.1`（localhost only）に変更
- Baketaはローカル翻訳アプリであり、同一マシン上のC#クライアントとPython gRPCサーバー間でのみ通信するため、外部アクセスは不要

## Changes
- `start_server.py`: `--host`デフォルト値を`127.0.0.1`に変更
- `ocr_server_surya.py`: `[::]`を`127.0.0.1`に変更
- `ocr_server_surya_onnx.py`: `[::]`を`127.0.0.1`に変更
- `ocr_server_paddlevl.py`: `[::]`を`127.0.0.1`に変更
- `ocr_server_hybrid.py`: `[::]`を`127.0.0.1`に変更
- `README.md`: ドキュメント更新

## Root Cause
gRPCサーバーが`0.0.0.0`（IPv4全インターフェース）や`[::]`（IPv6全インターフェース）にバインドすると、外部ネットワークからの接続を受け付ける状態になり、Windowsがファイアウォール警告を表示します。

## Solution
ローカルループバックアドレス`127.0.0.1`にバインドすることで、ローカルマシン内の通信のみに制限し、ファイアウォール警告を抑制します。

## Test plan
- [x] ビルド成功確認
- [x] Geminiコードレビュー完了（問題なし）
- [ ] 実機でファイアウォールダイアログが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)