### PR TITLE
fix: Cloud AI翻訳のトークン消費をUIに反映 (#258)

### DIFF
--- a/Baketa.Application/DI/Modules/ApplicationModule.cs
+++ b/Baketa.Application/DI/Modules/ApplicationModule.cs
@@ -288,15 +288,18 @@ public sealed class ApplicationModule : ServiceModuleBase
         // 例: services.AddSingleton<ITextReplacementService, TextReplacementService>();
 
         // 🔥 [Issue #78 Phase 4] 並列翻訳オーケストレーター登録
-        // Pro/Premiaプラン向けのCloud AI翻訳並列実行・相互検証機能
+        // Pro/Premium/Ultimateプラン向けのCloud AI翻訳並列実行・相互検証機能
         Console.WriteLine("🔥 [Issue #78 Phase 4] ParallelTranslationOrchestrator DI登録開始");
         services.AddSingleton<Baketa.Application.Services.Translation.ParallelTranslationOrchestrator>(provider =>
         {
             var translationService = provider.GetRequiredService<TranslationAbstractions.ITranslationService>();
 
-            // Cloud AI関連サービス（オプショナル - Pro/Premiaプランのみ）
+            // Cloud AI関連サービス（オプショナル - Pro/Premium/Ultimateプランのみ）
             var fallbackOrchestrator = provider.GetService<Baketa.Core.Translation.Abstractions.IFallbackOrchestrator>();
             var crossValidator = provider.GetService<Baketa.Core.Abstractions.Validation.ICrossValidator>();
+
+            // Issue #258: トークン消費記録用にILicenseManagerを追加
+            var licenseManager = provider.GetRequiredService<Baketa.Core.Abstractions.License.ILicenseManager>();
             var logger = provider.GetRequiredService<ILogger<Baketa.Application.Services.Translation.ParallelTranslationOrchestrator>>();
 
             Console.WriteLine($"✅ [Issue #78 Phase 4] ParallelTranslationOrchestrator作成: " +
@@ -306,6 +309,7 @@ public sealed class ApplicationModule : ServiceModuleBase
                 translationService,
                 fallbackOrchestrator,
                 crossValidator,
+                licenseManager,
                 logger);
         });
         services.AddSingleton<Baketa.Core.Translation.Abstractions.IParallelTranslationOrchestrator>(


### PR DESCRIPTION
## Summary
- Cloud AI翻訳後のトークン消費がUIに反映されない問題を修正
- ParallelTranslationOrchestratorでCloud AI翻訳成功時にILicenseManager.ConsumeCloudAiTokensAsync()を呼び出すよう実装

## Changes
- ParallelTranslationOrchestratorにILicenseManager依存を追加
- RecordTokenConsumptionAsyncメソッドを追加（トークン消費記録）
- idempotencyKeyでリクエストIDを使用し二重消費を防止
- トークン消費記録の失敗は翻訳結果に影響させない（ログのみ）
- DI登録（ApplicationModule.cs）を更新
- テストケース4件追加（正常系、スキップ系、異常系）

## Gemini Code Review
- ✅ アーキテクチャ準拠（Clean Architecture）
- ✅ 堅牢な設計（try-catchでの保護）
- ✅ パフォーマンスへの配慮（ConfigureAwait(false)）
- ✅ 冪等性の確保（idempotencyKey）
- ✅ テストカバレッジ向上（指摘対応済み）

## Test Plan
- [x] 全18テストケース成功
- [x] トークン消費記録の正常系テスト
- [x] TotalTokens=0時のスキップテスト
- [x] API失敗時の翻訳成功テスト
- [x] 例外発生時の翻訳成功テスト

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)