### PR TITLE
feat: LoadingWindow UI簡素化 + Tips機能追加 (#259)

### DIFF
--- a/Baketa.UI/Resources/Strings.Designer.cs
+++ b/Baketa.UI/Resources/Strings.Designer.cs
@@ -526,6 +526,16 @@ public static class Strings
     public static string Loading_PreparingUI => GetString("Loading_PreparingUI");
     public static string Loading_SetupGpu => GetString("Loading_SetupGpu");
 
+    // [Issue #259] Loading Tips
+    public static string Loading_Tip_FirstLaunch_Ja => GetString("Loading_Tip_FirstLaunch_Ja");
+    public static string Loading_Tip_FirstLaunch_En => GetString("Loading_Tip_FirstLaunch_En");
+    public static string Loading_Tip_About_Ja => GetString("Loading_Tip_About_Ja");
+    public static string Loading_Tip_About_En => GetString("Loading_Tip_About_En");
+    public static string Loading_Tip_LiveMode_Ja => GetString("Loading_Tip_LiveMode_Ja");
+    public static string Loading_Tip_LiveMode_En => GetString("Loading_Tip_LiveMode_En");
+    public static string Loading_Tip_SingleshotMode_Ja => GetString("Loading_Tip_SingleshotMode_Ja");
+    public static string Loading_Tip_SingleshotMode_En => GetString("Loading_Tip_SingleshotMode_En");
+
     // ========== [Issue #78 Phase 5] Token Usage Alerts ==========
 
     public static string TokenUsage_Warning_Title => GetString("TokenUsage_Warning_Title");

--- a/Baketa.UI/Resources/Strings.en.resx
+++ b/Baketa.UI/Resources/Strings.en.resx
@@ -1227,6 +1227,32 @@
     <value>Setting up GPU environment...</value>
   </data>
 
+  <!-- [Issue #259] Loading Tips -->
+  <data name="Loading_Tip_FirstLaunch_Ja" xml:space="preserve">
+    <value>初回起動時は約10分かかることがあります。OCRモデルのダウンロードと初期化を行っています。</value>
+  </data>
+  <data name="Loading_Tip_FirstLaunch_En" xml:space="preserve">
+    <value>First launch may take up to 10 minutes. Downloading and initializing OCR models.</value>
+  </data>
+  <data name="Loading_Tip_About_Ja" xml:space="preserve">
+    <value>Baketaは画面上のテキストをリアルタイムで翻訳するオーバーレイアプリです。</value>
+  </data>
+  <data name="Loading_Tip_About_En" xml:space="preserve">
+    <value>Baketa is an overlay app that translates on-screen text in real-time.</value>
+  </data>
+  <data name="Loading_Tip_LiveMode_Ja" xml:space="preserve">
+    <value>Liveモード: 画面の変化を自動検出して継続的に翻訳します。ゲームプレイに最適。</value>
+  </data>
+  <data name="Loading_Tip_LiveMode_En" xml:space="preserve">
+    <value>Live mode: Automatically detects screen changes and translates continuously. Perfect for gameplay.</value>
+  </data>
+  <data name="Loading_Tip_SingleshotMode_Ja" xml:space="preserve">
+    <value>Singleshotモード: ボタンを押すたびに翻訳。静止画の翻訳に最適。</value>
+  </data>
+  <data name="Loading_Tip_SingleshotMode_En" xml:space="preserve">
+    <value>Singleshot mode: Translates when you press the button. Perfect for static images.</value>
+  </data>
+
   <!-- [Issue #78 Phase 5] Token Usage Alerts -->
   <data name="TokenUsage_Warning_Title" xml:space="preserve">
     <value>Token Usage Warning</value>

--- a/Baketa.UI/Resources/Strings.resx
+++ b/Baketa.UI/Resources/Strings.resx
@@ -1227,6 +1227,32 @@
     <value>GPU環境をセットアップしています...</value>
   </data>
 
+  <!-- [Issue #259] Loading Tips -->
+  <data name="Loading_Tip_FirstLaunch_Ja" xml:space="preserve">
+    <value>初回起動時は約10分かかることがあります。OCRモデルのダウンロードと初期化を行っています。</value>
+  </data>
+  <data name="Loading_Tip_FirstLaunch_En" xml:space="preserve">
+    <value>First launch may take up to 10 minutes. Downloading and initializing OCR models.</value>
+  </data>
+  <data name="Loading_Tip_About_Ja" xml:space="preserve">
+    <value>Baketaは画面上のテキストをリアルタイムで翻訳するオーバーレイアプリです。</value>
+  </data>
+  <data name="Loading_Tip_About_En" xml:space="preserve">
+    <value>Baketa is an overlay app that translates on-screen text in real-time.</value>
+  </data>
+  <data name="Loading_Tip_LiveMode_Ja" xml:space="preserve">
+    <value>Liveモード: 画面の変化を自動検出して継続的に翻訳します。ゲームプレイに最適。</value>
+  </data>
+  <data name="Loading_Tip_LiveMode_En" xml:space="preserve">
+    <value>Live mode: Automatically detects screen changes and translates continuously. Perfect for gameplay.</value>
+  </data>
+  <data name="Loading_Tip_SingleshotMode_Ja" xml:space="preserve">
+    <value>Singleshotモード: ボタンを押すたびに翻訳。静止画の翻訳に最適。</value>
+  </data>
+  <data name="Loading_Tip_SingleshotMode_En" xml:space="preserve">
+    <value>Singleshot mode: Translates when you press the button. Perfect for static images.</value>
+  </data>
+
   <!-- [Issue #78 Phase 5] Token Usage Alerts -->
   <data name="TokenUsage_Warning_Title" xml:space="preserve">
     <value>トークン使用量警告</value>

--- a/Baketa.UI/Views/LoadingWindow.axaml
+++ b/Baketa.UI/Views/LoadingWindow.axaml
@@ -5,12 +5,11 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:i="using:Avalonia.Xaml.Interactivity"
         xmlns:behaviors="using:Baketa.UI.Behaviors"
-        mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="400"
+        mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="350"
         x:Class="Baketa.UI.Views.LoadingWindow"
         x:DataType="vm:LoadingViewModel"
         Title="Baketa - Loading..."
-        Width="600" MinHeight="400"
-        SizeToContent="Height"
+        Width="500" Height="350"
         CanResize="False"
         WindowStartupLocation="CenterScreen"
         SystemDecorations="None"
@@ -41,14 +40,14 @@
       <behaviors:WindowDragBehavior />
     </i:Interaction.Behaviors>
 
-    <Grid RowDefinitions="Auto,*,Auto" Margin="40">
+    <Grid RowDefinitions="Auto,Auto,*,Auto,Auto" Margin="40,32,40,24">
 
       <!-- Issue #239: 閉じるボタン（右上に配置） -->
       <Button Grid.Row="0"
               Name="CloseButton"
               HorizontalAlignment="Right"
               VerticalAlignment="Top"
-              Margin="0,-28,-28,0"
+              Margin="0,-20,-28,0"
               Width="32" Height="32"
               CornerRadius="16"
               Background="#27272A"
@@ -62,73 +61,75 @@
                    VerticalAlignment="Center"/>
       </Button>
 
-      <!-- Baketaアイコン (256px) -->
+      <!-- Baketaアイコン -->
       <Image Grid.Row="0"
              Source="avares://Baketa/Assets/Icons/baketa-256.png"
-             Width="128" Height="128"
+             Width="96" Height="96"
              HorizontalAlignment="Center"
-             Margin="0,0,0,32"/>
+             Margin="0,0,0,24"/>
 
-      <!-- 初期化ステップリスト -->
-      <ItemsControl Grid.Row="1"
-                    ItemsSource="{Binding InitializationSteps}"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Center">
-        <ItemsControl.ItemTemplate>
-          <DataTemplate>
-            <StackPanel Margin="0,6">
-              <Grid ColumnDefinitions="Auto,*">
-                <!-- ステータスアイコン -->
-                <Border Grid.Column="0"
-                        Width="24" Height="24"
-                        CornerRadius="12"
-                        Background="{Binding StatusColor}"
-                        Margin="0,0,16,0">
-                  <TextBlock Text="{Binding StatusIcon}"
-                             Foreground="White"
-                             FontSize="12"
-                             HorizontalAlignment="Center"
-                             VerticalAlignment="Center"/>
-                </Border>
+      <!-- Issue #259: 統合プログレスバー -->
+      <StackPanel Grid.Row="1"
+                  HorizontalAlignment="Stretch"
+                  Margin="20,0">
+        <!-- 現在のステップメッセージ -->
+        <TextBlock Text="{Binding CurrentStepMessage}"
+                   Foreground="#E4E4E7"
+                   FontSize="14"
+                   HorizontalAlignment="Center"
+                   TextWrapping="NoWrap"
+                   TextTrimming="CharacterEllipsis"/>
+        <!-- プログレスバー -->
+        <ProgressBar Value="{Binding OverallProgress}"
+                     IsIndeterminate="{Binding IsIndeterminate}"
+                     Minimum="0"
+                     Maximum="100"
+                     Height="6"
+                     Margin="0,12,0,0"
+                     Foreground="#3B82F6"
+                     Background="#27272A"/>
+      </StackPanel>
 
-                <!-- メッセージ -->
-                <TextBlock Grid.Column="1"
-                           Text="{Binding Message}"
-                           Foreground="#E4E4E7"
-                           FontSize="14"
-                           VerticalAlignment="Center"/>
-              </Grid>
-
-              <!-- プログレスバー（実行中のステップで表示） -->
-              <StackPanel IsVisible="{Binding IsInProgress}"
-                          Margin="40,4,0,0">
-                <!-- [Issue #185] 詳細メッセージ (ダウンロード進捗など) -->
-                <TextBlock Text="{Binding DetailMessage}"
+      <!-- Issue #259: Tips（フェードアニメーション付き） -->
+      <Border Grid.Row="2"
+              Background="#27272A"
+              CornerRadius="8"
+              Margin="0,24,0,0"
+              Padding="16,12"
+              VerticalAlignment="Center">
+        <StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Center">
+          <TextBlock Text="💡"
+                     FontSize="16"
+                     Margin="0,0,8,0"
+                     VerticalAlignment="Center"/>
+          <TransitioningContentControl Content="{Binding CurrentTip}"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center">
+            <TransitioningContentControl.PageTransition>
+              <CrossFade Duration="0:0:0.5" />
+            </TransitioningContentControl.PageTransition>
+            <TransitioningContentControl.ContentTemplate>
+              <DataTemplate>
+                <TextBlock Text="{Binding}"
                            Foreground="#A1A1AA"
                            FontSize="12"
-                           TextWrapping="NoWrap"
-                           TextTrimming="CharacterEllipsis"
-                           IsVisible="{Binding HasDetailMessage}"/>
-                <!-- プログレスバー（不確定アニメーション対応） -->
-                <ProgressBar Value="{Binding Progress}"
-                             IsIndeterminate="{Binding IsIndeterminate}"
-                             Minimum="0"
-                             Maximum="100"
-                             Height="4"
-                             Margin="0,4,0,0"
-                             Foreground="#3B82F6"
-                             Background="#27272A"/>
-              </StackPanel>
-            </StackPanel>
-          </DataTemplate>
-        </ItemsControl.ItemTemplate>
-      </ItemsControl>
+                           TextWrapping="Wrap"
+                           MaxWidth="360"
+                           TextAlignment="Left"/>
+              </DataTemplate>
+            </TransitioningContentControl.ContentTemplate>
+          </TransitioningContentControl>
+        </StackPanel>
+      </Border>
+
+      <!-- スペーサー -->
+      <Border Grid.Row="3" Height="16"/>
 
       <!-- フッター -->
-      <StackPanel Grid.Row="2"
+      <StackPanel Grid.Row="4"
                   Orientation="Vertical"
-                  HorizontalAlignment="Center"
-                  Margin="0,32,0,0">
+                  HorizontalAlignment="Center">
         <TextBlock Text="Baketa - Game Translation Overlay"
                    Foreground="#71717A"
                    FontSize="12"


### PR DESCRIPTION
## Summary
- LoadingWindowのUIを簡素化し、Tips機能を追加してユーザー体験を向上
- 6ステップ個別表示 → 単一の統合プログレスバー
- 5秒ごとにローテーションするヒント表示

## Changes

### UI変更
- ItemsControl削除 → シンプルなレイアウト
- ウィンドウサイズ最適化（600x400 → 500x350）
- TransitioningContentControl + CrossFadeでTipsアニメーション

### LoadingViewModel改修
- CurrentStepMessage, OverallProgress, CurrentTipプロパティ追加
- StepWeightsによる重み付け進捗計算
- Observable.Interval + WhenActivatedでTipsローテーション

### リソース追加
- 日英両言語対応のTips（4種類）
  - 初回起動の説明
  - Baketaの概要
  - Liveモードの説明
  - Singleshotモードの説明

## Gemini Code Review
- ✅ ReactiveUIパターン準拠
- ✅ Avaloniaベストプラクティス準拠
- ✅ TipRotationIntervalSeconds定数化
- ✅ WhenActivated内でイベントのライフサイクル管理

## Test Plan
- [x] ビルド成功
- [x] UI表示確認
- [x] Tips表示とローテーション確認
- [x] 日英ローカライズ確認

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)