### PR TITLE
feat(#273): Cloud翻訳設定の自動同期システムを実装

### DIFF
--- a/Baketa.Core/Abstractions/Translation/ICloudTranslationAvailabilityService.cs
+++ b/Baketa.Core/Abstractions/Translation/ICloudTranslationAvailabilityService.cs
@@ -1,0 +1,129 @@
+namespace Baketa.Core.Abstractions.Translation;
+
+/// <summary>
+/// Cloud翻訳機能の利用可否を統合管理するサービス
+/// Issue #273: FeatureFlags.EnableCloudTranslation と Translation.EnableCloudAiTranslation の
+/// 2つの設定を統合し、一貫した可用性判定を提供する
+/// </summary>
+public interface ICloudTranslationAvailabilityService
+{
+    /// <summary>
+    /// Cloud翻訳の利用資格があるかどうか（プラン/ライセンスベース）
+    /// Pro/Premium/Ultimate プラン、またはプロモーションコード適用時に true
+    /// </summary>
+    bool IsEntitled { get; }
+
+    /// <summary>
+    /// ユーザーがCloud翻訳を希望しているかどうか（ユーザー設定ベース）
+    /// TranslationSettings.EnableCloudAiTranslation の値
+    /// </summary>
+    bool IsPreferred { get; }
+
+    /// <summary>
+    /// Cloud翻訳が実際に有効かどうか（計算プロパティ）
+    /// IsEntitled AND IsPreferred の両方が true の場合のみ true
+    /// </summary>
+    bool IsEffectivelyEnabled { get; }
+
+    /// <summary>
+    /// Cloud翻訳の可用性が変更された時に発火するイベント
+    /// プラン変更、プロモーション適用、ユーザー設定変更時に発火
+    /// </summary>
+    event EventHandler<CloudTranslationAvailabilityChangedEventArgs>? AvailabilityChanged;
+
+    /// <summary>
+    /// 現在の状態を強制的に再評価して更新する
+    /// ログイン後やプラン変更後に呼び出す
+    /// </summary>
+    Task RefreshStateAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// ユーザーの希望設定を更新する
+    /// UI層からCloud翻訳の有効/無効を切り替える際に使用
+    /// </summary>
+    /// <param name="preferred">Cloud翻訳を希望するかどうか</param>
+    /// <param name="cancellationToken">キャンセルトークン</param>
+    Task SetPreferredAsync(bool preferred, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Cloud翻訳可用性変更イベントの引数
+/// </summary>
+public sealed class CloudTranslationAvailabilityChangedEventArgs : EventArgs
+{
+    /// <summary>
+    /// 変更前の有効状態
+    /// </summary>
+    public required bool WasEnabled { get; init; }
+
+    /// <summary>
+    /// 変更後の有効状態
+    /// </summary>
+    public required bool IsEnabled { get; init; }
+
+    /// <summary>
+    /// 変更の理由
+    /// </summary>
+    public required CloudTranslationChangeReason Reason { get; init; }
+
+    /// <summary>
+    /// 利用資格があるかどうか
+    /// </summary>
+    public required bool IsEntitled { get; init; }
+
+    /// <summary>
+    /// ユーザーが希望しているかどうか
+    /// </summary>
+    public required bool IsPreferred { get; init; }
+}
+
+/// <summary>
+/// Cloud翻訳可用性変更の理由
+/// </summary>
+public enum CloudTranslationChangeReason
+{
+    /// <summary>
+    /// 初期化時
+    /// </summary>
+    Initialization,
+
+    /// <summary>
+    /// プランアップグレード（Free→Pro, Pro→Premium, Pro→Ultimate など）
+    /// </summary>
+    PlanUpgrade,
+
+    /// <summary>
+    /// プランダウングレード（Premium→Pro, Pro→Free など）
+    /// </summary>
+    PlanDowngrade,
+
+    /// <summary>
+    /// プロモーションコード適用
+    /// </summary>
+    PromotionApplied,
+
+    /// <summary>
+    /// プロモーション期限切れ
+    /// </summary>
+    PromotionExpired,
+
+    /// <summary>
+    /// ユーザーが手動で設定変更
+    /// </summary>
+    UserPreferenceChanged,
+
+    /// <summary>
+    /// ログイン状態復元
+    /// </summary>
+    LoginRestored,
+
+    /// <summary>
+    /// ログアウト
+    /// </summary>
+    Logout,
+
+    /// <summary>
+    /// オフライン検出
+    /// </summary>
+    OfflineDetected
+}

--- a/Baketa.Infrastructure/DI/Modules/InfrastructureModule.cs
+++ b/Baketa.Infrastructure/DI/Modules/InfrastructureModule.cs
@@ -409,6 +409,12 @@ public class InfrastructureModule : ServiceModuleBase
         // services.AddSingleton<ITranslationService, DefaultTranslationService>(); // TranslationServiceExtensions.AddTranslationServices()で登録
 
         Console.WriteLine("✅ Issue #147 Phase 3.2: ハイブリッド翻訳戦略システム登録完了");
+
+        // 🆕 Issue #273: Cloud翻訳可用性統合サービス
+        // ライセンス状態とユーザー設定を統合して一貫した可用性判定を提供
+        services.AddSingleton<Baketa.Core.Abstractions.Translation.ICloudTranslationAvailabilityService,
+            Baketa.Infrastructure.Translation.Services.CloudTranslationAvailabilityService>();
+        Console.WriteLine("✅ [Issue #273] CloudTranslationAvailabilityService登録完了 - ライセンス×設定統合");
     }
 
     /// <summary>

--- a/Baketa.Infrastructure/Translation/Services/CloudTranslationAvailabilityService.cs
+++ b/Baketa.Infrastructure/Translation/Services/CloudTranslationAvailabilityService.cs
@@ -1,0 +1,258 @@
+using Baketa.Core.Abstractions.License;
+using Baketa.Core.Abstractions.Settings;
+using Baketa.Core.Abstractions.Translation;
+using Baketa.Core.License.Events;
+using Baketa.Core.License.Models;
+using Baketa.Core.Settings;
+using Microsoft.Extensions.Logging;
+
+namespace Baketa.Infrastructure.Translation.Services;
+
+/// <summary>
+/// Cloud翻訳機能の利用可否を統合管理するサービス実装
+/// Issue #273: ライセンス状態とユーザー設定を統合して一貫した可用性判定を提供
+/// </summary>
+public sealed class CloudTranslationAvailabilityService : ICloudTranslationAvailabilityService, IDisposable
+{
+    private readonly ILicenseManager _licenseManager;
+    private readonly IUnifiedSettingsService _unifiedSettingsService;
+    private readonly ILogger<CloudTranslationAvailabilityService> _logger;
+    private readonly object _stateLock = new();
+
+    private bool _isEntitled;
+    private bool _isPreferred;
+    private bool _wasEnabled;
+    private bool _disposed;
+
+    public CloudTranslationAvailabilityService(
+        ILicenseManager licenseManager,
+        IUnifiedSettingsService unifiedSettingsService,
+        ILogger<CloudTranslationAvailabilityService> logger)
+    {
+        _licenseManager = licenseManager ?? throw new ArgumentNullException(nameof(licenseManager));
+        _unifiedSettingsService = unifiedSettingsService ?? throw new ArgumentNullException(nameof(unifiedSettingsService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // 初期状態を設定
+        _isEntitled = _licenseManager.IsFeatureAvailable(FeatureType.CloudAiTranslation);
+        var currentSettings = _unifiedSettingsService.GetTranslationSettings();
+        _isPreferred = currentSettings.EnableCloudAiTranslation;
+        _wasEnabled = IsEffectivelyEnabled;
+
+        // ライセンス状態変更の監視
+        _licenseManager.StateChanged += OnLicenseStateChanged;
+
+        // 翻訳設定変更の監視（IUnifiedSettingsService経由）
+        _unifiedSettingsService.SettingsChanged += OnSettingsChanged;
+
+        _logger.LogInformation(
+            "CloudTranslationAvailabilityService 初期化完了: IsEntitled={IsEntitled}, IsPreferred={IsPreferred}, IsEffectivelyEnabled={IsEffectivelyEnabled}",
+            _isEntitled, _isPreferred, IsEffectivelyEnabled);
+    }
+
+    /// <inheritdoc />
+    public bool IsEntitled { get { lock (_stateLock) { return _isEntitled; } } }
+
+    /// <inheritdoc />
+    public bool IsPreferred { get { lock (_stateLock) { return _isPreferred; } } }
+
+    /// <inheritdoc />
+    public bool IsEffectivelyEnabled { get { lock (_stateLock) { return _isEntitled && _isPreferred; } } }
+
+    /// <inheritdoc />
+    public event EventHandler<CloudTranslationAvailabilityChangedEventArgs>? AvailabilityChanged;
+
+    /// <inheritdoc />
+    public async Task RefreshStateAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Cloud翻訳可用性を再評価します");
+
+        // ライセンス状態を強制更新
+        await _licenseManager.RefreshStateAsync(cancellationToken).ConfigureAwait(false);
+
+        var newEntitled = _licenseManager.IsFeatureAvailable(FeatureType.CloudAiTranslation);
+        var currentSettings = _unifiedSettingsService.GetTranslationSettings();
+        var newPreferred = currentSettings.EnableCloudAiTranslation;
+
+        UpdateState(newEntitled, newPreferred, CloudTranslationChangeReason.Initialization);
+    }
+
+    /// <inheritdoc />
+    public async Task SetPreferredAsync(bool preferred, CancellationToken cancellationToken = default)
+    {
+        bool currentIsPreferred;
+        bool currentIsEntitled;
+        lock (_stateLock)
+        {
+            currentIsPreferred = _isPreferred;
+            currentIsEntitled = _isEntitled;
+        }
+
+        if (currentIsPreferred == preferred)
+        {
+            _logger.LogDebug("Cloud翻訳希望設定は変更なし: {Preferred}", preferred);
+            return;
+        }
+
+        _logger.LogInformation("Cloud翻訳希望設定を変更: {OldValue} → {NewValue}", currentIsPreferred, preferred);
+
+        // 現在の設定をクローンして更新
+        var currentSettings = _unifiedSettingsService.GetTranslationSettings();
+        if (currentSettings is not TranslationSettings concreteSettings)
+        {
+            _logger.LogWarning("設定のクローンに失敗しました: 具象型TranslationSettingsへのキャストに失敗");
+            return;
+        }
+        var settings = concreteSettings.Clone();
+
+        settings.EnableCloudAiTranslation = preferred;
+        settings.DefaultEngine = (preferred && currentIsEntitled) ? TranslationEngine.Gemini : TranslationEngine.NLLB200;
+
+        await _unifiedSettingsService.UpdateTranslationSettingsAsync(settings, cancellationToken).ConfigureAwait(false);
+
+        if (preferred && currentIsEntitled)
+        {
+            _logger.LogInformation("DefaultEngine を Gemini に自動設定");
+        }
+        else if (!preferred)
+        {
+            _logger.LogInformation("DefaultEngine を NLLB200 に自動設定");
+        }
+
+        UpdateState(currentIsEntitled, preferred, CloudTranslationChangeReason.UserPreferenceChanged);
+    }
+
+    private void OnLicenseStateChanged(object? sender, LicenseStateChangedEventArgs e)
+    {
+        bool wasEntitled;
+        bool currentPreferred;
+        lock (_stateLock)
+        {
+            wasEntitled = _isEntitled;
+            currentPreferred = _isPreferred;
+        }
+
+        var newEntitled = _licenseManager.IsFeatureAvailable(FeatureType.CloudAiTranslation);
+        var reason = MapLicenseChangeReason(e.Reason);
+
+        _logger.LogInformation(
+            "ライセンス状態変更検出: OldPlan={OldPlan}, NewPlan={NewPlan}, NewEntitled={NewEntitled}, Reason={Reason}",
+            e.OldState.CurrentPlan, e.NewState.CurrentPlan, newEntitled, reason);
+
+        UpdateState(newEntitled, currentPreferred, reason);
+
+        // 利用資格を得た場合、ユーザー設定も自動的に有効化（新規アップグレードのUX向上）
+        if (newEntitled && !wasEntitled)
+        {
+            _logger.LogInformation("利用資格を取得したため、Cloud翻訳を自動有効化します");
+            FireAndForgetSetPreferredAsync(true);
+        }
+    }
+
+    /// <summary>
+    /// Fire-and-forget呼び出しを安全に行うヘルパーメソッド
+    /// </summary>
+    private async void FireAndForgetSetPreferredAsync(bool preferred)
+    {
+        try
+        {
+            await SetPreferredAsync(preferred, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Cloud翻訳の自動有効化中に予期せぬエラーが発生しました。");
+        }
+    }
+
+    private void OnSettingsChanged(object? sender, SettingsChangedEventArgs e)
+    {
+        // 翻訳設定の変更のみを処理
+        if (e.SettingsType != SettingsType.Translation)
+        {
+            return;
+        }
+
+        bool currentIsPreferred;
+        bool currentIsEntitled;
+        lock (_stateLock)
+        {
+            currentIsPreferred = _isPreferred;
+            currentIsEntitled = _isEntitled;
+        }
+
+        var currentSettings = _unifiedSettingsService.GetTranslationSettings();
+        var newPreferred = currentSettings.EnableCloudAiTranslation;
+
+        if (currentIsPreferred != newPreferred)
+        {
+            _logger.LogDebug("翻訳設定変更検出: IsPreferred {OldValue} → {NewValue}", currentIsPreferred, newPreferred);
+            UpdateState(currentIsEntitled, newPreferred, CloudTranslationChangeReason.UserPreferenceChanged);
+        }
+    }
+
+    private void UpdateState(bool newEntitled, bool newPreferred, CloudTranslationChangeReason reason)
+    {
+        CloudTranslationAvailabilityChangedEventArgs? eventArgs = null;
+
+        lock (_stateLock)
+        {
+            var wasEnabled = _wasEnabled;
+            _isEntitled = newEntitled;
+            _isPreferred = newPreferred;
+            var nowEnabled = _isEntitled && _isPreferred;
+
+            if (wasEnabled != nowEnabled)
+            {
+                _wasEnabled = nowEnabled;
+
+                _logger.LogInformation(
+                    "Cloud翻訳可用性が変更されました: {WasEnabled} → {NowEnabled} (Reason: {Reason})",
+                    wasEnabled, nowEnabled, reason);
+
+                eventArgs = new CloudTranslationAvailabilityChangedEventArgs
+                {
+                    WasEnabled = wasEnabled,
+                    IsEnabled = nowEnabled,
+                    Reason = reason,
+                    IsEntitled = _isEntitled,
+                    IsPreferred = _isPreferred
+                };
+            }
+        }
+
+        // イベント発火はロック外で行う（デッドロック防止）
+        if (eventArgs is not null)
+        {
+            AvailabilityChanged?.Invoke(this, eventArgs);
+        }
+    }
+
+    /// <summary>
+    /// LicenseChangeReason を CloudTranslationChangeReason にマッピング
+    /// </summary>
+    private static CloudTranslationChangeReason MapLicenseChangeReason(LicenseChangeReason licenseReason)
+    {
+        return licenseReason switch
+        {
+            LicenseChangeReason.InitialLoad or LicenseChangeReason.CacheLoad or LicenseChangeReason.ServerRefresh
+                => CloudTranslationChangeReason.Initialization,
+            LicenseChangeReason.PlanUpgrade => CloudTranslationChangeReason.PlanUpgrade,
+            LicenseChangeReason.PlanDowngrade or LicenseChangeReason.SubscriptionExpired
+                => CloudTranslationChangeReason.PlanDowngrade,
+            LicenseChangeReason.PromotionApplied => CloudTranslationChangeReason.PromotionApplied,
+            LicenseChangeReason.PromotionExpired => CloudTranslationChangeReason.PromotionExpired,
+            LicenseChangeReason.Logout or LicenseChangeReason.SessionInvalidation
+                => CloudTranslationChangeReason.Logout,
+            _ => CloudTranslationChangeReason.Initialization
+        };
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _licenseManager.StateChanged -= OnLicenseStateChanged;
+        _unifiedSettingsService.SettingsChanged -= OnSettingsChanged;
+    }
+}

--- a/tests/Baketa.Infrastructure.Tests/Translation/Services/CloudTranslationAvailabilityServiceTests.cs
+++ b/tests/Baketa.Infrastructure.Tests/Translation/Services/CloudTranslationAvailabilityServiceTests.cs
@@ -1,0 +1,559 @@
+using Baketa.Core.Abstractions.License;
+using Baketa.Core.Abstractions.Settings;
+using Baketa.Core.Abstractions.Translation;
+using Baketa.Core.License.Events;
+using Baketa.Core.License.Models;
+using Baketa.Core.Settings;
+using Baketa.Infrastructure.Translation.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Baketa.Infrastructure.Tests.Translation.Services;
+
+/// <summary>
+/// CloudTranslationAvailabilityServiceのユニットテスト
+/// Issue #273: Cloud翻訳設定の自動同期システム
+/// </summary>
+public class CloudTranslationAvailabilityServiceTests : IDisposable
+{
+    private readonly Mock<ILicenseManager> _mockLicenseManager;
+    private readonly Mock<IUnifiedSettingsService> _mockUnifiedSettingsService;
+    private readonly Mock<ILogger<CloudTranslationAvailabilityService>> _mockLogger;
+    private TranslationSettings _translationSettings;
+    private CloudTranslationAvailabilityService? _service;
+
+    public CloudTranslationAvailabilityServiceTests()
+    {
+        _mockLicenseManager = new Mock<ILicenseManager>();
+        _mockUnifiedSettingsService = new Mock<IUnifiedSettingsService>();
+        _mockLogger = new Mock<ILogger<CloudTranslationAvailabilityService>>();
+
+        _translationSettings = new TranslationSettings
+        {
+            EnableCloudAiTranslation = false,
+            DefaultEngine = TranslationEngine.NLLB200
+        };
+
+        // GetTranslationSettingsのモック設定
+        _mockUnifiedSettingsService.Setup(x => x.GetTranslationSettings()).Returns(() => _translationSettings);
+
+        // デフォルト: Freeプラン（Cloud翻訳未対応）
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(false);
+    }
+
+    public void Dispose()
+    {
+        _service?.Dispose();
+    }
+
+    private CloudTranslationAvailabilityService CreateService()
+    {
+        _service = new CloudTranslationAvailabilityService(
+            _mockLicenseManager.Object,
+            _mockUnifiedSettingsService.Object,
+            _mockLogger.Object);
+        return _service;
+    }
+
+    /// <summary>
+    /// SettingsChangedイベントを発火させるヘルパーメソッド
+    /// </summary>
+    private void RaiseSettingsChanged(TranslationSettings newSettings)
+    {
+        _translationSettings = newSettings;
+        _mockUnifiedSettingsService.Raise(
+            x => x.SettingsChanged += null,
+            _mockUnifiedSettingsService.Object,
+            new SettingsChangedEventArgs("Translation", SettingsType.Translation));
+    }
+
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_WithFreeUserAndCloudDisabled_InitializesCorrectly()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(false);
+        _translationSettings.EnableCloudAiTranslation = false;
+
+        // Act
+        var service = CreateService();
+
+        // Assert
+        Assert.False(service.IsEntitled);
+        Assert.False(service.IsPreferred);
+        Assert.False(service.IsEffectivelyEnabled);
+    }
+
+    [Fact]
+    public void Constructor_WithProUserAndCloudEnabled_InitializesCorrectly()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        _translationSettings.EnableCloudAiTranslation = true;
+
+        // Act
+        var service = CreateService();
+
+        // Assert
+        Assert.True(service.IsEntitled);
+        Assert.True(service.IsPreferred);
+        Assert.True(service.IsEffectivelyEnabled);
+    }
+
+    [Fact]
+    public void Constructor_WithProUserButCloudDisabled_IsEffectivelyDisabled()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        _translationSettings.EnableCloudAiTranslation = false;
+
+        // Act
+        var service = CreateService();
+
+        // Assert
+        Assert.True(service.IsEntitled);
+        Assert.False(service.IsPreferred);
+        Assert.False(service.IsEffectivelyEnabled);
+    }
+
+    [Fact]
+    public void Constructor_WithFreeUserButCloudEnabled_IsEffectivelyDisabled()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(false);
+        _translationSettings.EnableCloudAiTranslation = true;
+
+        // Act
+        var service = CreateService();
+
+        // Assert
+        Assert.False(service.IsEntitled);
+        Assert.True(service.IsPreferred);
+        Assert.False(service.IsEffectivelyEnabled);
+    }
+
+    [Fact]
+    public void Constructor_WithNullLicenseManager_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new CloudTranslationAvailabilityService(
+                null!,
+                _mockUnifiedSettingsService.Object,
+                _mockLogger.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithNullUnifiedSettingsService_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new CloudTranslationAvailabilityService(
+                _mockLicenseManager.Object,
+                null!,
+                _mockLogger.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new CloudTranslationAvailabilityService(
+                _mockLicenseManager.Object,
+                _mockUnifiedSettingsService.Object,
+                null!));
+    }
+
+    #endregion
+
+    #region RefreshStateAsync Tests
+
+    [Fact]
+    public async Task RefreshStateAsync_ShouldCallLicenseManagerRefresh()
+    {
+        // Arrange
+        var service = CreateService();
+
+        // Act
+        await service.RefreshStateAsync();
+
+        // Assert
+        _mockLicenseManager.Verify(x => x.RefreshStateAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshStateAsync_WhenEntitlementChanges_FiresEvent()
+    {
+        // Arrange
+        var service = CreateService();
+        var eventFired = false;
+        CloudTranslationAvailabilityChangedEventArgs? receivedArgs = null;
+
+        service.AvailabilityChanged += (sender, args) =>
+        {
+            eventFired = true;
+            receivedArgs = args;
+        };
+
+        // シミュレート: RefreshStateAsync後にEntitledがtrueになる
+        _translationSettings.EnableCloudAiTranslation = true;
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+
+        // Act
+        await service.RefreshStateAsync();
+
+        // Assert
+        Assert.True(eventFired);
+        Assert.NotNull(receivedArgs);
+        Assert.False(receivedArgs.WasEnabled);
+        Assert.True(receivedArgs.IsEnabled);
+        Assert.Equal(CloudTranslationChangeReason.Initialization, receivedArgs.Reason);
+    }
+
+    #endregion
+
+    #region SetPreferredAsync Tests
+
+    [Fact]
+    public async Task SetPreferredAsync_WhenChangingToTrue_UpdatesSettings()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        var service = CreateService();
+
+        // Act
+        await service.SetPreferredAsync(true);
+
+        // Assert
+        _mockUnifiedSettingsService.Verify(
+            x => x.UpdateTranslationSettingsAsync(
+                It.Is<TranslationSettings>(s =>
+                    s.EnableCloudAiTranslation == true &&
+                    s.DefaultEngine == TranslationEngine.Gemini),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SetPreferredAsync_WhenChangingToFalse_SetsNLLB200Engine()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        _translationSettings.EnableCloudAiTranslation = true;
+        var service = CreateService();
+
+        // Act
+        await service.SetPreferredAsync(false);
+
+        // Assert
+        _mockUnifiedSettingsService.Verify(
+            x => x.UpdateTranslationSettingsAsync(
+                It.Is<TranslationSettings>(s =>
+                    s.EnableCloudAiTranslation == false &&
+                    s.DefaultEngine == TranslationEngine.NLLB200),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SetPreferredAsync_WhenValueUnchanged_DoesNotUpdateSettings()
+    {
+        // Arrange
+        var service = CreateService();
+
+        // Act
+        await service.SetPreferredAsync(false); // 既にfalse
+
+        // Assert
+        _mockUnifiedSettingsService.Verify(
+            x => x.UpdateTranslationSettingsAsync(It.IsAny<TranslationSettings>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SetPreferredAsync_WhenEntitledUserEnablesCloud_FiresEvent()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        var service = CreateService();
+        var eventFired = false;
+        CloudTranslationAvailabilityChangedEventArgs? receivedArgs = null;
+
+        service.AvailabilityChanged += (sender, args) =>
+        {
+            eventFired = true;
+            receivedArgs = args;
+        };
+
+        // Act
+        await service.SetPreferredAsync(true);
+
+        // Assert
+        Assert.True(eventFired);
+        Assert.NotNull(receivedArgs);
+        Assert.False(receivedArgs.WasEnabled);
+        Assert.True(receivedArgs.IsEnabled);
+        Assert.Equal(CloudTranslationChangeReason.UserPreferenceChanged, receivedArgs.Reason);
+    }
+
+    #endregion
+
+    #region License State Change Tests
+
+    [Fact]
+    public void OnLicenseStateChanged_WhenUpgradedToPro_AutoEnablesCloudTranslation()
+    {
+        // Arrange
+        var service = CreateService();
+
+        var oldState = new LicenseState { CurrentPlan = PlanType.Free };
+        var newState = new LicenseState { CurrentPlan = PlanType.Pro };
+        var eventArgs = new LicenseStateChangedEventArgs(oldState, newState, LicenseChangeReason.PlanUpgrade);
+
+        // シミュレート: アップグレード後にEntitledがtrueになる
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+
+        // Act
+        _mockLicenseManager.Raise(x => x.StateChanged += null, _mockLicenseManager.Object, eventArgs);
+
+        // Assert: 自動的にSetPreferredAsync(true)が呼ばれる
+        _mockUnifiedSettingsService.Verify(
+            x => x.UpdateTranslationSettingsAsync(
+                It.Is<TranslationSettings>(s => s.EnableCloudAiTranslation == true),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void OnLicenseStateChanged_WhenDowngradedToFree_DoesNotAutoDisable()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        _translationSettings.EnableCloudAiTranslation = true;
+        var service = CreateService();
+
+        var oldState = new LicenseState { CurrentPlan = PlanType.Pro };
+        var newState = new LicenseState { CurrentPlan = PlanType.Free };
+        var eventArgs = new LicenseStateChangedEventArgs(oldState, newState, LicenseChangeReason.PlanDowngrade);
+
+        // シミュレート: ダウングレード後にEntitledがfalseになる
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(false);
+
+        CloudTranslationAvailabilityChangedEventArgs? receivedArgs = null;
+        service.AvailabilityChanged += (sender, args) => receivedArgs = args;
+
+        // Act
+        _mockLicenseManager.Raise(x => x.StateChanged += null, _mockLicenseManager.Object, eventArgs);
+
+        // Assert: イベントは発火するが、設定は自動的に無効化されない（ユーザーの選択を尊重）
+        Assert.NotNull(receivedArgs);
+        Assert.True(receivedArgs.WasEnabled);
+        Assert.False(receivedArgs.IsEnabled);
+        Assert.Equal(CloudTranslationChangeReason.PlanDowngrade, receivedArgs.Reason);
+
+        // SetPreferredAsync(false)は呼ばれない（ダウングレード時は自動無効化しない）
+        _mockUnifiedSettingsService.Verify(
+            x => x.UpdateTranslationSettingsAsync(
+                It.Is<TranslationSettings>(s => s.EnableCloudAiTranslation == false),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void OnLicenseStateChanged_WhenPromotionApplied_AutoEnablesAndFiresEvent()
+    {
+        // Arrange
+        var service = CreateService();
+
+        var oldState = new LicenseState { CurrentPlan = PlanType.Free };
+        var newState = new LicenseState { CurrentPlan = PlanType.Pro };
+        var eventArgs = new LicenseStateChangedEventArgs(oldState, newState, LicenseChangeReason.PromotionApplied);
+
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+
+        CloudTranslationAvailabilityChangedEventArgs? receivedArgs = null;
+        service.AvailabilityChanged += (sender, args) => receivedArgs = args;
+
+        // Act
+        _mockLicenseManager.Raise(x => x.StateChanged += null, _mockLicenseManager.Object, eventArgs);
+
+        // Assert: プロモーション適用時、自動的にCloud翻訳が有効化される
+        // 最終的なイベント理由は UserPreferenceChanged（SetPreferredAsync経由での有効化のため）
+        Assert.NotNull(receivedArgs);
+        Assert.True(receivedArgs.IsEnabled);
+        Assert.True(receivedArgs.IsEntitled);
+        Assert.True(receivedArgs.IsPreferred);
+        // 注: 理由は UserPreferenceChanged になる（自動有効化はSetPreferredAsync経由）
+        Assert.Equal(CloudTranslationChangeReason.UserPreferenceChanged, receivedArgs.Reason);
+    }
+
+    #endregion
+
+    #region Settings Change Tests
+
+    [Fact]
+    public void OnSettingsChanged_WhenPreferenceChanges_FiresEvent()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        var service = CreateService();
+
+        CloudTranslationAvailabilityChangedEventArgs? receivedArgs = null;
+        service.AvailabilityChanged += (sender, args) => receivedArgs = args;
+
+        // Act: 設定変更をシミュレート
+        var newSettings = new TranslationSettings { EnableCloudAiTranslation = true };
+        RaiseSettingsChanged(newSettings);
+
+        // Assert
+        Assert.NotNull(receivedArgs);
+        Assert.False(receivedArgs.WasEnabled);
+        Assert.True(receivedArgs.IsEnabled);
+        Assert.Equal(CloudTranslationChangeReason.UserPreferenceChanged, receivedArgs.Reason);
+    }
+
+    [Fact]
+    public void OnSettingsChanged_WhenPreferenceUnchanged_DoesNotFireEvent()
+    {
+        // Arrange
+        var service = CreateService();
+
+        var eventFired = false;
+        service.AvailabilityChanged += (sender, args) => eventFired = true;
+
+        // Act: 同じ設定値で変更通知
+        var sameSettings = new TranslationSettings { EnableCloudAiTranslation = false };
+        RaiseSettingsChanged(sameSettings);
+
+        // Assert
+        Assert.False(eventFired);
+    }
+
+    [Fact]
+    public void OnSettingsChanged_WhenNonTranslationSettings_DoesNotProcess()
+    {
+        // Arrange
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        _translationSettings.EnableCloudAiTranslation = true;
+        var service = CreateService();
+
+        var eventFired = false;
+        service.AvailabilityChanged += (sender, args) => eventFired = true;
+
+        // Act: OCR設定変更（Translation以外）
+        _mockUnifiedSettingsService.Raise(
+            x => x.SettingsChanged += null,
+            _mockUnifiedSettingsService.Object,
+            new SettingsChangedEventArgs("Ocr", SettingsType.Ocr));
+
+        // Assert: Translationタイプ以外は処理されない
+        Assert.False(eventFired);
+    }
+
+    #endregion
+
+    #region Dispose Tests
+
+    [Fact]
+    public void Dispose_UnsubscribesFromEvents()
+    {
+        // Arrange
+        var service = CreateService();
+
+        // Act
+        service.Dispose();
+
+        // Assert: Disposeが例外なく完了することを確認
+        service.Dispose(); // 2回目のDisposeも安全
+    }
+
+    [Fact]
+    public void Dispose_CanBeCalledMultipleTimes()
+    {
+        // Arrange
+        var service = CreateService();
+
+        // Act & Assert: 複数回Disposeしても例外が発生しない
+        service.Dispose();
+        service.Dispose();
+        service.Dispose();
+    }
+
+    #endregion
+
+    #region Integration Scenario Tests
+
+    [Fact]
+    public async Task Scenario_FreeUserUpgradesToPro_CloudTranslationAutoEnabled()
+    {
+        // Arrange: Freeユーザーとして開始
+        var service = CreateService();
+        Assert.False(service.IsEffectivelyEnabled);
+
+        // Act: Proプランにアップグレード
+        var oldState = new LicenseState { CurrentPlan = PlanType.Free };
+        var newState = new LicenseState { CurrentPlan = PlanType.Pro };
+        var eventArgs = new LicenseStateChangedEventArgs(oldState, newState, LicenseChangeReason.PlanUpgrade);
+
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        _mockLicenseManager.Raise(x => x.StateChanged += null, _mockLicenseManager.Object, eventArgs);
+
+        // Assert: Cloud翻訳が自動有効化される
+        Assert.True(service.IsEntitled);
+        _mockUnifiedSettingsService.Verify(
+            x => x.UpdateTranslationSettingsAsync(
+                It.Is<TranslationSettings>(s => s.EnableCloudAiTranslation == true),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Scenario_ProUserDisablesCloud_ThenReEnables()
+    {
+        // Arrange: Proユーザーとして開始（Cloud有効）
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        _translationSettings.EnableCloudAiTranslation = true;
+        var service = CreateService();
+        Assert.True(service.IsEffectivelyEnabled);
+
+        // Act 1: Cloud翻訳を無効化
+        await service.SetPreferredAsync(false);
+        Assert.False(service.IsPreferred);
+
+        // Act 2: Cloud翻訳を再有効化
+        await service.SetPreferredAsync(true);
+
+        // Assert
+        _mockUnifiedSettingsService.Verify(
+            x => x.UpdateTranslationSettingsAsync(
+                It.Is<TranslationSettings>(s => s.EnableCloudAiTranslation == true && s.DefaultEngine == TranslationEngine.Gemini),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void Scenario_UserTogglesLocalEngine_SettingsChangeDetected()
+    {
+        // Arrange: Proユーザーとして開始
+        _mockLicenseManager.Setup(x => x.IsFeatureAvailable(FeatureType.CloudAiTranslation)).Returns(true);
+        var service = CreateService();
+
+        CloudTranslationAvailabilityChangedEventArgs? receivedArgs = null;
+        service.AvailabilityChanged += (sender, args) => receivedArgs = args;
+
+        // Act: UIでローカルエンジンからAIエンジンに切り替え（SettingsChangedイベント経由）
+        var newSettings = new TranslationSettings { EnableCloudAiTranslation = true };
+        RaiseSettingsChanged(newSettings);
+
+        // Assert: 設定変更が検出され、イベントが発火
+        Assert.NotNull(receivedArgs);
+        Assert.True(receivedArgs.IsEnabled);
+        Assert.True(service.IsPreferred);
+        Assert.True(service.IsEffectivelyEnabled);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- ICloudTranslationAvailabilityServiceを追加し、ライセンス状態とユーザー設定を統合してCloud翻訳の利用可否を一元管理
- IOptionsMonitor（appsettings.json監視）からIUnifiedSettingsService.SettingsChangedイベント（ユーザー設定JSON監視）に変更
- スレッドセーフティ対応（_stateLockによる状態保護）

## Changes
- `ICloudTranslationAvailabilityService`: 統合インターフェース追加
- `CloudTranslationAvailabilityService`: リアルタイム設定同期を実装
- `AggregatedChunksReadyEventHandler`: Cloud翻訳可用性チェックを統合
- 24件のユニットテスト追加（全件パス）

## Bug Fixed
UI上でオフライン翻訳を選択してもAI翻訳が実行される問題を修正

## Test plan
- [x] CloudTranslationAvailabilityServiceTests: 24件成功
- [x] Core.Tests: 670件成功
- [x] Application.Tests: 122件成功
- [ ] 手動テスト: UI上で翻訳エンジン切り替えが正しく反映されることを確認

Closes #273

🤖 Generated with [Claude Code](https://claude.ai/code)