### PR TITLE
fix(license): Issue #280+#281 セッショントークン伝播とgRPC例外処理を修正

### DIFF
--- a/Baketa.Core/Abstractions/License/ILicenseManager.cs
+++ b/Baketa.Core/Abstractions/License/ILicenseManager.cs
@@ -117,6 +117,18 @@ public interface ILicenseManager
     /// IsFeatureAvailable(CloudAiTranslation) を再評価できるようにします。
     /// </remarks>
     void NotifyBonusTokensLoaded();
+
+    /// <summary>
+    /// セッショントークンを設定（Issue #280+#281）
+    /// 認証成功時にAccessTokenをLicenseState.SessionIdに反映する
+    /// </summary>
+    /// <param name="sessionToken">認証セッションのAccessToken（nullでクリア）</param>
+    /// <remarks>
+    /// このメソッドはAuthStatusChangedイベントでログイン検知時に呼び出されます。
+    /// Cloud AI翻訳APIの認証に使用するセッショントークンを設定します。
+    /// ログアウト時はnullを渡してクリアします。
+    /// </remarks>
+    void SetSessionToken(string? sessionToken);
 }
 
 /// <summary>

--- a/Baketa.Infrastructure/License/Services/LicenseManager.cs
+++ b/Baketa.Infrastructure/License/Services/LicenseManager.cs
@@ -1119,6 +1119,22 @@ public sealed class LicenseManager : ILicenseManager, IDisposable
         OnStateChanged(currentState, currentState, LicenseChangeReason.PromotionApplied);
     }
 
+    /// <inheritdoc/>
+    public void SetSessionToken(string? sessionToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        lock (_stateLock)
+        {
+            _sessionToken = sessionToken;
+            _currentState = _currentState with { SessionId = sessionToken };
+        }
+
+        _logger.LogInformation(
+            "[Issue #280+#281] セッショントークン設定: HasToken={HasToken}",
+            !string.IsNullOrEmpty(sessionToken));
+    }
+
     /// <summary>
     /// [Issue #275] 有効なプロモーションがある場合、状態にプロモーション設定をマージ
     /// [Issue #280+#281] プロモーションはボーナストークン付与のみ、プランは変更しない

--- a/tests/Baketa.Infrastructure.Tests/License/LicenseManagerTests.cs
+++ b/tests/Baketa.Infrastructure.Tests/License/LicenseManagerTests.cs
@@ -470,6 +470,61 @@ public class LicenseManagerTests : IDisposable
 
     #endregion
 
+    #region SetSessionToken Tests (Issue #280+#281)
+
+    [Fact]
+    public void SetSessionToken_ValidToken_UpdatesCurrentState()
+    {
+        // Arrange
+        var token = "test-session-token-abc123";
+
+        // Act
+        _licenseManager.SetSessionToken(token);
+
+        // Assert
+        Assert.Equal(token, _licenseManager.CurrentState.SessionId);
+    }
+
+    [Fact]
+    public void SetSessionToken_NullToken_ClearsSessionId()
+    {
+        // Arrange - first set a token
+        _licenseManager.SetSessionToken("initial-token");
+        Assert.Equal("initial-token", _licenseManager.CurrentState.SessionId);
+
+        // Act - clear with null
+        _licenseManager.SetSessionToken(null);
+
+        // Assert
+        Assert.Null(_licenseManager.CurrentState.SessionId);
+    }
+
+    [Fact]
+    public void SetSessionToken_EmptyString_SetsEmptySessionId()
+    {
+        // Arrange
+        _licenseManager.SetSessionToken("initial-token");
+
+        // Act
+        _licenseManager.SetSessionToken(string.Empty);
+
+        // Assert
+        Assert.Equal(string.Empty, _licenseManager.CurrentState.SessionId);
+    }
+
+    [Fact]
+    public void SetSessionToken_AfterDispose_ThrowsObjectDisposedException()
+    {
+        // Arrange
+        _licenseManager.Dispose();
+
+        // Act & Assert
+        Assert.Throws<ObjectDisposedException>(() =>
+            _licenseManager.SetSessionToken("token"));
+    }
+
+    #endregion
+
     #region StateChanged Event Tests
 
     [Fact]


### PR DESCRIPTION
## Summary

- Cloud AI翻訳がリリースビルドで動作しない問題を修正（SessionIdが空）
- gRPC接続タイムアウト時のUnobservedTaskExceptionクラッシュを修正
- Geminiコードレビューの改善提案（ロジック共通化）を反映

## 変更内容

### セッショントークン伝播の修正
- `ILicenseManager.SetSessionToken()` メソッドを追加
- `LicenseManager` でスレッドセーフな実装
- `BonusSyncHostedService` でログイン/ログアウト時にトークンを設定
- 起動時の既存セッション対応（AuthStatusChangedは起動時に呼ばれないため）

### gRPC例外処理の修正
- `PythonServerHealthMonitor` でタイムアウト時の例外観測を追加
- `ContinueWith(OnlyOnFaulted)` パターンで未観測例外を防止

### テスト
- `SetSessionToken` 用の単体テスト4件を追加

## 関連Issue

- Closes #280
- Closes #281

## Test plan

- [ ] LicenseManagerTests 48件が全てパス
- [ ] リリースビルドでCloud AI翻訳が動作することを確認
- [ ] ログイン→Cloud AI翻訳→ログアウトのフローで問題なし
- [ ] 長時間稼働でUnobservedTaskExceptionが発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)