### PR TITLE
fix(translate,license): Issue #275+#283 複数テキスト翻訳対応とプロモーション修正

### DIFF
--- a/Baketa.UI/ViewModels/Settings/LicenseInfoViewModel.cs
+++ b/Baketa.UI/ViewModels/Settings/LicenseInfoViewModel.cs
@@ -578,7 +578,8 @@ public sealed class LicenseInfoViewModel : ViewModelBase
                 FileName = planChangeUrl,
                 UseShellExecute = true
             });
-            StatusMessage = Strings.License_OpeningPlanPage;
+            // [Issue #283] ブラウザが開くのでステータスメッセージは不要
+            StatusMessage = string.Empty;
             IsStatusError = false;
             _logger?.LogInformation("プラン変更ページを開きました: {Url}", planChangeUrl);
         }


### PR DESCRIPTION
## Summary
- **Issue #275**: Cloud AI翻訳で複数テキスト+BoundingBox形式に対応（DirectGeminiImageTranslatorと同等のプロンプト）
- **Issue #283**: プロモーションコード適用時のプラン表示問題とボーナストークン永続化を修正

## Changes

### Issue #275: Cloud AI翻訳の複数テキスト対応
| ファイル | 変更内容 |
|---------|---------|
| `relay-server/src/translate.ts` | Gemini/OpenAIプロンプトを複数テキスト形式に更新、maxOutputTokens増加(1024→2048) |
| `RelayServerClient.cs` | `texts`配列レスポンス対応、`SuccessWithMultipleTexts()`で返却 |

### Issue #283: プロモーションコード修正
| ファイル | 変更内容 |
|---------|---------|
| `LicenseManager.cs` | `OnPromotionApplied`: CurrentPlan変更せず維持（Patreonプラン優先）、ボーナストークン再取得追加 |
| `LicenseInfoViewModel.cs` | 「プラン変更ページを開いています」メッセージを削除 |

## Test plan
- [ ] Cloud AI翻訳で複数テキストが正しくオーバーレイ表示されることを確認
- [ ] プロモーションコード適用後もPatreonプランが維持されることを確認
- [ ] プロモーションコード適用後にボーナストークンが正しく表示されることを確認
- [ ] 設定画面を閉じて再度開いてもボーナストークンが維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)