### PR TITLE
perf(#306): 自動アップデート再起動時間を高速化 (Phase 1)

### DIFF
--- a/Baketa.UI/Services/ZipUpdateHandler.cs
+++ b/Baketa.UI/Services/ZipUpdateHandler.cs
@@ -308,8 +308,8 @@ public sealed class ZipSparkleUpdater : SparkleUpdater
             :: /E: サブディレクトリ含む全コピー（/MIRと異なり既存ファイルを削除しない）
             :: /MT:4: 4スレッド並列処理
             :: /NP /NFL /NDL: 進捗・ファイル名・ディレクトリ名表示抑制
-            :: /R:3 /W:1: リトライ3回、待機1秒
-            robocopy "{{escapedSourceDir}}" "{{escapedTargetDir}}" /E /MT:4 /NP /NFL /NDL /R:3 /W:1
+            :: /R:3 /W:3: リトライ3回、待機3秒（AV対策）
+            robocopy "{{escapedSourceDir}}" "{{escapedTargetDir}}" /E /MT:4 /NP /NFL /NDL /R:3 /W:3
 
             :: robocopyの終了コード: 0-7は成功、8以上はエラー
             if errorlevel 8 (


### PR DESCRIPTION
## Summary
- 自動アップデート時の再起動時間を高速化（Phase 1）
- xcopy → robocopy への変更で差分のみ並列コピー
- PowerShell 100ms待機でプロセス終了検知を10倍高速化

## Changes
| 変更点 | 旧 | 新 |
|-------|-----|-----|
| ファイルコピー | xcopy（全ファイル逐次） | robocopy /MIR /MT:4（差分のみ4スレッド並列） |
| 待機間隔 | 1秒ごとにtasklist | 100msごとにPowerShell Get-Process |
| 除外設定 | なし | grpc_server/dist, venv*を除外 |

## robocopyオプション
| オプション | 効果 |
|-----------|------|
| `/MIR` | ミラーリング（差分のみコピー） |
| `/MT:4` | 4スレッド並列処理 |
| `/NP /NFL /NDL` | 進捗・ファイル名・ディレクトリ名表示抑制 |
| `/R:3 /W:1` | リトライ3回、待機1秒 |
| `/XD` | grpc_serverの不要ディレクトリを除外 |

## Expected Results
| 指標 | 現状 | Phase 1目標 |
|------|------|-------------|
| 再起動時間 | 約60秒 | 30〜40秒 |

## Test plan
- [ ] 自動アップデートをトリガー（手動でタグ作成）
- [ ] アプリ終了→ファイルコピー→再起動の時間を計測
- [ ] grpc_serverディレクトリが正しく除外されることを確認

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)