### PR TITLE
feat(#207): カスタムドメイン(baketa.app)対応 - APIエンドポイント移行

### DIFF
--- a/Baketa.Core/CrashReporting/CrashReportService.cs
+++ b/Baketa.Core/CrashReporting/CrashReportService.cs
@@ -401,7 +401,7 @@ public sealed partial class CrashReportService : ICrashReportService
     /// <summary>
     /// クラッシュレポート送信先エンドポイント（レガシー用）
     /// </summary>
-    private const string CrashReportEndpointUrl = "https://baketa-relay.suke009.workers.dev/api/crash-report";
+    private const string CrashReportEndpointUrl = "https://api.baketa.app/api/crash-report";
 
     /// <inheritdoc />
     public Task DeleteCrashReportAsync(string reportId)

--- a/Baketa.Core/Settings/CloudTranslationSettings.cs
+++ b/Baketa.Core/Settings/CloudTranslationSettings.cs
@@ -18,7 +18,7 @@ public sealed class CloudTranslationSettings
     /// </remarks>
     [SettingMetadata(SettingLevel.Advanced, "Cloud Translation", "Relay Server URL",
         Description = "Cloud AI翻訳中継サーバーのURL")]
-    public string RelayServerUrl { get; set; } = "https://baketa-relay.suke009.workers.dev";
+    public string RelayServerUrl { get; set; } = "https://api.baketa.app";
 
     /// <summary>
     /// API Key（クライアント認証用）- 非推奨

--- a/Baketa.Core/Settings/LicenseSettings.cs
+++ b/Baketa.Core/Settings/LicenseSettings.cs
@@ -113,7 +113,7 @@ public sealed class LicenseSettings
     /// </summary>
     [SettingMetadata(SettingLevel.Advanced, "License", "Promotion API Endpoint",
         Description = "プロモーションコード検証サーバーのエンドポイントURL")]
-    public string PromotionApiEndpoint { get; set; } = "https://baketa-relay.suke009.workers.dev/api/promotion/redeem";
+    public string PromotionApiEndpoint { get; set; } = "https://api.baketa.app/api/promotion/redeem";
 
     /// <summary>
     /// 適用済みプロモーションコード（DPAPI暗号化）

--- a/Baketa.Infrastructure/Analytics/UsageAnalyticsService.cs
+++ b/Baketa.Infrastructure/Analytics/UsageAnalyticsService.cs
@@ -87,7 +87,7 @@ public sealed class UsageAnalyticsService : IUsageAnalyticsService, IAsyncDispos
         // 設定読み込み
         // [Issue #297] ApiKeyは不要に - セッショントークン認証に変更
         _analyticsEndpoint = configuration["Analytics:Endpoint"]
-            ?? "https://baketa-relay.suke009.workers.dev/api/analytics/events";
+            ?? "https://api.baketa.app/api/analytics/events";
         _enableInDebug = configuration.GetValue("Analytics:EnableInDebug", false);
 
         // [Issue #307] アプリバージョン取得

--- a/Baketa.Infrastructure/Auth/JwtTokenService.cs
+++ b/Baketa.Infrastructure/Auth/JwtTokenService.cs
@@ -24,7 +24,7 @@ public sealed class JwtTokenService(
     private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
     private readonly ILogger<JwtTokenService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     private readonly string _relayServerUrl = settings?.Value?.RelayServerUrl
-        ?? "https://baketa-relay.suke009.workers.dev";
+        ?? "https://api.baketa.app";
 
     private JwtTokenPair? _currentTokenPair;
     private readonly object _tokenLock = new();

--- a/Baketa.Infrastructure/DI/Modules/InfrastructureModule.cs
+++ b/Baketa.Infrastructure/DI/Modules/InfrastructureModule.cs
@@ -1080,7 +1080,7 @@ public class InfrastructureModule : ServiceModuleBase
         {
             services.Configure<Core.Settings.CloudTranslationSettings>(options =>
             {
-                options.RelayServerUrl = "https://baketa-relay.suke009.workers.dev";
+                options.RelayServerUrl = "https://api.baketa.app";
                 options.TimeoutSeconds = 30;
                 options.MaxRetries = 2;
                 options.PrimaryProviderId = "gemini";
@@ -1095,7 +1095,7 @@ public class InfrastructureModule : ServiceModuleBase
         // [Issue #261] Named HttpClient "RelayServer" 登録（ConsentService等で使用）
         services.AddHttpClient("RelayServer", client =>
         {
-            client.BaseAddress = new Uri("https://baketa-relay.suke009.workers.dev");
+            client.BaseAddress = new Uri("https://api.baketa.app");
             client.DefaultRequestHeaders.Add("Accept", "application/json");
         });
         Console.WriteLine("✅ Named HttpClient [RelayServer] 登録完了");
@@ -1629,7 +1629,7 @@ public class InfrastructureModule : ServiceModuleBase
                 CrashReporting.CrashReportSender.HttpClientName)
             .ConfigureHttpClient(client =>
             {
-                client.BaseAddress = new Uri("https://baketa-relay.suke009.workers.dev");
+                client.BaseAddress = new Uri("https://api.baketa.app");
                 client.Timeout = TimeSpan.FromSeconds(30);
                 client.DefaultRequestHeaders.Add("User-Agent", "Baketa/1.0");
                 client.DefaultRequestHeaders.Add("Accept", "application/json");

--- a/Baketa.Infrastructure/DI/Modules/LicenseModule.cs
+++ b/Baketa.Infrastructure/DI/Modules/LicenseModule.cs
@@ -113,7 +113,7 @@ public sealed class LicenseModule : ServiceModuleBase
         services.AddHttpClient<License.PromotionCodeService>()
             .ConfigureHttpClient((sp, client) =>
             {
-                client.BaseAddress = new Uri("https://baketa-relay.suke009.workers.dev");
+                client.BaseAddress = new Uri("https://api.baketa.app");
                 client.Timeout = TimeSpan.FromSeconds(30);
                 client.DefaultRequestHeaders.Add("User-Agent", "Baketa/1.0");
                 client.DefaultRequestHeaders.Add("Accept", "application/json");
@@ -148,7 +148,7 @@ public sealed class LicenseModule : ServiceModuleBase
         services.AddHttpClient<License.BonusTokenService>()
             .ConfigureHttpClient((sp, client) =>
             {
-                client.BaseAddress = new Uri("https://baketa-relay.suke009.workers.dev");
+                client.BaseAddress = new Uri("https://api.baketa.app");
                 client.Timeout = TimeSpan.FromSeconds(30);
                 client.DefaultRequestHeaders.Add("User-Agent", "Baketa/1.0");
                 client.DefaultRequestHeaders.Add("Accept", "application/json");
@@ -171,7 +171,7 @@ public sealed class LicenseModule : ServiceModuleBase
                 var config = sp.GetRequiredService<IConfiguration>();
                 client.BaseAddress = new Uri(
                     config["CloudTranslation:RelayServerUrl"]
-                    ?? "https://baketa-relay.suke009.workers.dev");
+                    ?? "https://api.baketa.app");
                 client.Timeout = TimeSpan.FromSeconds(30);
                 client.DefaultRequestHeaders.Add("User-Agent", "Baketa/1.0");
                 client.DefaultRequestHeaders.Add("Accept", "application/json");


### PR DESCRIPTION
## Summary
- カスタムドメイン `baketa.app` 取得に伴い、APIエンドポイントを移行
- `baketa-relay.suke009.workers.dev` → `api.baketa.app`

## 変更内容
### クライアント側APIエンドポイント更新（11箇所）
- `Baketa.Core/Settings/CloudTranslationSettings.cs` - RelayServerUrl
- `Baketa.Core/Settings/LicenseSettings.cs` - PromotionApiEndpoint
- `Baketa.Core/CrashReporting/CrashReportService.cs` - CrashReportEndpointUrl
- `Baketa.Infrastructure/Analytics/UsageAnalyticsService.cs` - analyticsEndpoint
- `Baketa.Infrastructure/Auth/JwtTokenService.cs` - relayServerUrl
- `Baketa.Infrastructure/DI/Modules/InfrastructureModule.cs` - HttpClient BaseAddress（3箇所）
- `Baketa.Infrastructure/DI/Modules/LicenseModule.cs` - HttpClient BaseAddress（3箇所）

## インフラ設定（Cloudflare）
- ✅ ドメイン取得: `baketa.app` ($14.20/年)
- ✅ DNS設定: `api` → AAAA `100::` (Proxied)
- ✅ Workers Route: `api.baketa.app/*` → `baketa-relay`
- ✅ WAF Rate Limiting: 20 requests / 10 seconds

## メール設定
- ✅ Email Routing: `contact@baketa.app` → Gmail + Discord通知
- ✅ Resend: `mail.baketa.app` (SPF/DKIM/DMARC設定済み)
- ✅ Supabase SMTP: `noreply@mail.baketa.app`

## 関連Issue
- Closes #207
- Closes #175

## Test plan
- [ ] ビルド成功を確認
- [ ] `api.baketa.app` へのAPI呼び出しが正常に動作
- [ ] Cloud AI翻訳が正常に動作
- [ ] 認証フローが正常に動作

🤖 Generated with [Claude Code](https://claude.ai/code)