### PR TITLE
feat(#381): Cloud翻訳用画像のダウンスケール＋JPEG最適化

### DIFF
--- a/Baketa.Application/EventHandlers/Translation/AggregatedChunksReadyEventHandler.cs
+++ b/Baketa.Application/EventHandlers/Translation/AggregatedChunksReadyEventHandler.cs
@@ -1348,12 +1348,17 @@ public sealed class AggregatedChunksReadyEventHandler : IEventProcessor<Aggregat
             var sessionToken = _licenseManager!.CurrentState.SessionId;
 
             // 並列翻訳リクエストを作成
+            // [Issue #381] ImageWidth/HeightにはCloud画像の実サイズを使用（ログ・トークン推定用）
+            // CloudImageWidth/Heightが0（未設定）の場合は元サイズにフォールバック
+            var cloudW = eventData.CloudImageWidth > 0 ? eventData.CloudImageWidth : eventData.ImageWidth;
+            var cloudH = eventData.CloudImageHeight > 0 ? eventData.CloudImageHeight : eventData.ImageHeight;
             var request = new ParallelTranslationRequest
             {
                 OcrChunks = chunks,
                 ImageBase64 = eventData.ImageBase64!, // HasImageData で null でないことが保証済み
-                ImageWidth = eventData.ImageWidth,
-                ImageHeight = eventData.ImageHeight,
+                MimeType = "image/jpeg", // [Issue #381] JPEG変換済み
+                ImageWidth = cloudW,
+                ImageHeight = cloudH,
                 SourceLanguage = languagePair.SourceCode,
                 TargetLanguage = languagePair.TargetCode,
                 SessionToken = sessionToken,
@@ -1362,8 +1367,8 @@ public sealed class AggregatedChunksReadyEventHandler : IEventProcessor<Aggregat
             };
 
             _logger?.LogDebug(
-                "🌐 [Phase4] ParallelTranslationRequest作成: Chunks={Chunks}, ImageSize={Width}x{Height}, Lang={Source}→{Target}",
-                chunks.Count, eventData.ImageWidth, eventData.ImageHeight,
+                "🌐 [Phase4] ParallelTranslationRequest作成: Chunks={Chunks}, CloudImageSize={Width}x{Height}, Lang={Source}→{Target}",
+                chunks.Count, cloudW, cloudH,
                 languagePair.SourceCode, languagePair.TargetCode);
 
             // 並列翻訳を実行（ShouldUseParallelTranslation で null でないことが保証済み）

--- a/Baketa.Core/Abstractions/Translation/ITextChunkAggregatorService.cs
+++ b/Baketa.Core/Abstractions/Translation/ITextChunkAggregatorService.cs
@@ -46,9 +46,11 @@ public interface ITextChunkAggregatorService
     /// 次回のAggregatedChunksReadyEvent発行時に画像データが含まれます
     /// </summary>
     /// <param name="imageBase64">画像データ（Base64エンコード）</param>
-    /// <param name="width">画像幅</param>
-    /// <param name="height">画像高さ</param>
-    void SetImageContext(string imageBase64, int width, int height);
+    /// <param name="width">画像幅（座標マッピング用、元サイズ）</param>
+    /// <param name="height">画像高さ（座標マッピング用、元サイズ）</param>
+    /// <param name="cloudImageWidth">[Issue #381] 実際に送信するCloud画像幅（ログ・トークン推定用）</param>
+    /// <param name="cloudImageHeight">[Issue #381] 実際に送信するCloud画像高さ（ログ・トークン推定用）</param>
+    void SetImageContext(string imageBase64, int width, int height, int cloudImageWidth = 0, int cloudImageHeight = 0);
 
     /// <summary>
     /// [Issue #78 Phase 4] 画像コンテキストをクリア

--- a/Baketa.Core/Events/Translation/AggregatedChunksReadyEvent.cs
+++ b/Baketa.Core/Events/Translation/AggregatedChunksReadyEvent.cs
@@ -133,6 +133,18 @@ public sealed class AggregatedChunksReadyEvent : EventBase
     public bool HasPreComputedCloudResult => PreComputedCloudResult?.IsSuccess == true;
 
     /// <summary>
+    /// [Issue #381] 実際に送信するCloud画像幅（ログ・トークン推定用）
+    /// 0の場合はImageWidth（元サイズ）がフォールバックとして使用される
+    /// </summary>
+    public int CloudImageWidth { get; init; }
+
+    /// <summary>
+    /// [Issue #381] 実際に送信するCloud画像高さ（ログ・トークン推定用）
+    /// 0の場合はImageHeight（元サイズ）がフォールバックとして使用される
+    /// </summary>
+    public int CloudImageHeight { get; init; }
+
+    /// <summary>
     /// [Issue #379] 翻訳モード（Singleshotモード時にGateフィルタリングをバイパス）
     /// </summary>
     public TranslationMode TranslationMode { get; init; } = TranslationMode.Live;


### PR DESCRIPTION
## Summary

- Cloud AI翻訳に送信する画像を最大960px長辺にダウンスケール（BoundingBox座標は0-1000正規化のため影響なし）
- PNG→JPEG(quality=85)変換で画像サイズ約30%削減（182KB→126KB）
- Fork-Join結果をSetImageContextパスで再利用し、重複するダウンスケール処理を排除
- ログのResolution表示を実際の送信サイズ（960x540）に修正
- CloudImageWidth/CloudImageHeightをイベントチェーン全体で伝搬

## 実測結果（3840x2160キャプチャ）

| 指標 | Before (PNG) | After (JPEG) | 改善 |
|------|-------------|-------------|------|
| ImageSize | ~182KB | ~126KB | **30%削減** |
| Resolution | 3840x2160 (誤表示) | 960x540 (実サイズ) | 修正 |
| Fork-Join再利用 | - | 15/15 (100%) | 重複排除 |
| 翻訳精度 | 安定 | 安定（むしろ向上傾向） | 影響なし |

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `CoordinateBasedTranslationService.cs` | `PrepareCloudImageDataAsync`（ダウンスケール+JPEG変換）、`ConvertToJpeg`追加、Fork-Join再利用 |
| `ITextChunkAggregatorService.cs` | `SetImageContext`にcloudImageWidth/Height追加 |
| `AggregatedChunksReadyEvent.cs` | `CloudImageWidth`/`CloudImageHeight` init properties追加 |
| `TimedChunkAggregator.cs` | Cloud画像サイズのフィールド・伝搬追加 |
| `AggregatedChunksReadyEventHandler.cs` | CloudImageWidth/Height使用、MimeType=image/jpeg |

## Test plan

- [x] ビルド成功（0 errors）
- [x] テスト全件パス（165件）
- [x] 実機テスト: Resolution=960x540 表示確認
- [x] 実機テスト: JPEG変換（MimeType=image/jpeg）確認
- [x] 実機テスト: Fork-Join再利用 100%確認
- [x] 実機テスト: 翻訳精度に問題なし
- [ ] フルスクリーン/ウィンドウモード両方で回帰テスト

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)