### PR TITLE
feat(#391,#392): Cloud結果マッチング改善とオーバーレイ即時消失

### DIFF
--- a/Baketa.Application/Services/Translation/CoordinateBasedTranslationService.cs
+++ b/Baketa.Application/Services/Translation/CoordinateBasedTranslationService.cs
@@ -33,6 +33,7 @@ using Baketa.Core.Models.Roi; // [Issue #293] NormalizedRect
 using Baketa.Core.Models.Text; // [Issue #293] TextChangeWithGateResult, GateRegionInfo
 using IWindowManager = Baketa.Core.Abstractions.Platform.IWindowManager; // [Issue #293] ウィンドウ情報取得用
 using Baketa.Core.Utilities;
+// [Issue #392] Mechanism A/B削除: テキスト消失/変化検知はDetection段階のIsTextDisappearance()に移行
 using System.Diagnostics; // [Issue #290] Fork-Join計測用
 // NOTE: [PP-OCRv5削除] BatchProcessing参照削除
 using Baketa.Infrastructure.Translation.Local;
@@ -435,6 +436,7 @@ public sealed class CoordinateBasedTranslationService : IDisposable, IEventProce
                             return; // 早期リターン
                         }
 
+                        // [Issue #392] テキスト変化時のオーバーレイクリアはDetection段階のIsTextDisappearance()に移行
                         _logger?.LogDebug("🎯 [Issue #230] テキスト変化検知 - 翻訳を続行 (変化率: {ChangePercentage:P1})",
                             changeResult.ChangePercentage);
                     }


### PR DESCRIPTION
## Summary
- Cloud翻訳結果の重複排除とOverlapRatioフォールバックマッチングを追加 (#391)
- OCRテキスト座標の逆スケーリング修正(3840x2160→1280x720)によりテキスト消失判定を正常化 (#392)
- 翻訳完了後の高速チェックモード(1.5秒間隔)により、オーバーレイ消失を体感即時に改善 (#392)

## Test plan
- [x] ビルド成功（0エラー 0警告）
- [x] Application Tests: 165/165 成功
- [x] Infrastructure Tests: 671成功 / 4失敗（全てpre-existing）
- [x] 実機テスト: ウィンドウモード+150% DPIでオーバーレイ即時消失を確認

Closes #391
Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)