### PR TITLE
fix(#389,#390,#405,#406): ウィンドウクローズ検知、テキスト英語化、DPI修正、CJK折り返し

### DIFF
--- a/Baketa.Application/DI/Modules/ApplicationModule.cs
+++ b/Baketa.Application/DI/Modules/ApplicationModule.cs
@@ -275,6 +275,9 @@ public sealed class ApplicationModule : ServiceModuleBase
                 // Issue #293: 投機的OCRサービス（オプショナル）
                 var speculativeOcrService = provider.GetService<Baketa.Core.Abstractions.OCR.ISpeculativeOcrService>();
 
+                // [Issue #389] ウィンドウ存在チェック用
+                var windowManagerAdapter = provider.GetService<Baketa.Core.Abstractions.Platform.Windows.Adapters.IWindowManagerAdapter>();
+
                 return new Baketa.Application.Services.Translation.TranslationOrchestrationService(
                     captureService,
                     settingsService,
@@ -287,6 +290,7 @@ public sealed class ApplicationModule : ServiceModuleBase
                     fallbackOrchestrator,
                     licenseManager,
                     speculativeOcrService,
+                    windowManagerAdapter,
                     logger);
             }
             catch (Exception ex)

--- a/Baketa.Application/DI/Modules/CaptureModule.cs
+++ b/Baketa.Application/DI/Modules/CaptureModule.cs
@@ -85,12 +85,15 @@ public sealed class CaptureModule : ServiceModuleBase
                 var logger = provider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<AdaptiveCaptureServiceAdapter>>();
                 var coordinateTransformationService = provider.GetRequiredService<Baketa.Core.Abstractions.Services.ICoordinateTransformationService>();
                 var changeDetectionService = provider.GetService<Baketa.Core.Abstractions.Services.IImageChangeDetectionService>();
+                // [Issue #389] ウィンドウクローズ検知用
+                var eventAggregator = provider.GetService<Baketa.Core.Abstractions.Events.IEventAggregator>();
+                var windowManagerAdapter = provider.GetService<Baketa.Core.Abstractions.Platform.Windows.Adapters.IWindowManagerAdapter>();
 
                 logger.LogDebug("AdaptiveCaptureServiceAdapter インスタンス作成");
                 logger.LogInformation($"🎯 [PHASE_C] EnhancedImageChangeDetectionService統合: {(changeDetectionService != null ? "有効" : "無効")}");
                 logger.LogInformation("🎯 [WIN32_OVERLAY_FIX] CoordinateTransformationService統合: 動的ROIScaleFactor計算対応");
 
-                var adapter = new AdaptiveCaptureServiceAdapter(adaptiveService, logger, coordinateTransformationService, changeDetectionService);
+                var adapter = new AdaptiveCaptureServiceAdapter(adaptiveService, logger, coordinateTransformationService, changeDetectionService, eventAggregator, windowManagerAdapter);
                 logger.LogInformation("AdaptiveCaptureServiceAdapter 登録完了 - Phase C画面変化検知 + WIN32座標変換統合済み");
                 return adapter;
             }

--- a/Baketa.Application/Services/ApplicationInitializer.cs
+++ b/Baketa.Application/Services/ApplicationInitializer.cs
@@ -80,17 +80,17 @@ public class ApplicationInitializer : ILoadingScreenInitializer
             // [Issue #213] Phase 1: ダウンロードとGPUセットアップを並列実行
             // これらは独立した処理のため、並列化することで起動時間を短縮
             _logger.LogInformation("[Issue #213] Phase 1: コンポーネントダウンロードとGPUセットアップを並列実行");
-            ReportProgress("parallel_init", "初期化中（ダウンロード + GPU環境セットアップ）...", isCompleted: false, progress: 0);
+            ReportProgress("parallel_init", "Initializing (Download + GPU environment setup)...", isCompleted: false, progress: 0);
 
             var downloadTask = ExecuteStepAsync(
                 "download_components",
-                "コンポーネントをダウンロードしています...",
+                "Downloading components...",
                 DownloadMissingComponentsAsync,
                 cancellationToken);
 
             var gpuSetupTask = ExecuteStepAsync(
                 "setup_gpu",
-                "GPU環境をチェックしています...",
+                "Checking GPU environment...",
                 SetupGpuEnvironmentAsync,
                 cancellationToken);
 
@@ -100,7 +100,7 @@ public class ApplicationInitializer : ILoadingScreenInitializer
             // [Issue #213] Phase 2: 依存関係解決（シーケンシャル - サービス登録に依存）
             await ExecuteStepAsync(
                 "resolve_dependencies",
-                "依存関係を解決しています...",
+                "Resolving dependencies...",
                 ResolveDependenciesAsync,
                 cancellationToken).ConfigureAwait(false);
 
@@ -114,17 +114,17 @@ public class ApplicationInitializer : ILoadingScreenInitializer
             // [Issue #213] Phase 3: OCRと翻訳エンジンを並列初期化
             // これらは独立しており、並列化することで初期化時間を短縮
             _logger.LogInformation("[Issue #213] Phase 3: OCRと翻訳エンジンを並列初期化");
-            ReportProgress("parallel_engines", "OCR・翻訳エンジンを初期化中...", isCompleted: false, progress: 50);
+            ReportProgress("parallel_engines", "Initializing OCR and translation engines...", isCompleted: false, progress: 50);
 
             var ocrTask = ExecuteStepAsync(
                 "load_ocr",
-                "OCRモデルを読み込んでいます...",
+                "Loading OCR models...",
                 InitializeOcrAsync,
                 cancellationToken);
 
             var translationTask = ExecuteStepAsync(
                 "init_translation",
-                "翻訳エンジンを初期化しています...",
+                "Initializing translation engine...",
                 InitializeTranslationAsync,
                 cancellationToken);
 
@@ -134,7 +134,7 @@ public class ApplicationInitializer : ILoadingScreenInitializer
             // Step 4: UIコンポーネント準備（最後に実行）
             await ExecuteStepAsync(
                 "prepare_ui",
-                "UIコンポーネントを準備しています...",
+                "Preparing UI components...",
                 PrepareUIComponentsAsync,
                 cancellationToken).ConfigureAwait(false);
 
@@ -498,7 +498,7 @@ public class ApplicationInitializer : ILoadingScreenInitializer
         {
             // [Issue #198] 「ダウンロード完了」→「インストール完了」に変更
             // 解凍まで完了してから呼ばれるため、より正確な表現に
-            return $"{e.Component.DisplayName} のインストール完了";
+            return $"{e.Component.DisplayName} installation completed";
         }
 
         if (!string.IsNullOrEmpty(e.ErrorMessage))
@@ -511,7 +511,7 @@ public class ApplicationInitializer : ILoadingScreenInitializer
         var speedMBps = e.SpeedBytesPerSecond / 1024.0 / 1024.0;
 
         var etaStr = e.EstimatedTimeRemaining.HasValue
-            ? $" (残り {e.EstimatedTimeRemaining.Value.TotalSeconds:F0}秒)"
+            ? $" ({e.EstimatedTimeRemaining.Value.TotalSeconds:F0}s remaining)"
             : "";
 
         return $"{e.Component.DisplayName}: {receivedMB:F1}MB / {totalMB:F1}MB ({speedMBps:F1}MB/s){etaStr}";

--- a/Baketa.Application/Services/UI/WindowManagementService.cs
+++ b/Baketa.Application/Services/UI/WindowManagementService.cs
@@ -214,12 +214,20 @@ public sealed class WindowManagementService : IWindowManagementService, IDisposa
     {
         try
         {
-            // TODO: より詳細なウィンドウ有効性検証ロジックを実装
-            // - ウィンドウが存在するか
-            // - ウィンドウがアクセス可能か
-            // - セキュリティ制限に引っかからないか
+            if (windowInfo.Handle == IntPtr.Zero || string.IsNullOrEmpty(windowInfo.Title))
+                return false;
 
-            return windowInfo.Handle != IntPtr.Zero && !string.IsNullOrEmpty(windowInfo.Title);
+            // [Issue #389] IWindowManagerAdapter.GetWindowBounds() でウィンドウの実在を確認
+            // ウィンドウが閉じられている場合、GetWindowBounds() は null を返す
+            var bounds = _windowManager.GetWindowBounds(windowInfo.Handle);
+            if (bounds == null)
+            {
+                _logger.LogInformation("[Issue #389] ウィンドウが存在しません: '{Title}' (Handle={Handle})",
+                    windowInfo.Title, windowInfo.Handle);
+                return false;
+            }
+
+            return true;
         }
         catch (Exception ex)
         {

--- a/Baketa.Infrastructure/Services/BackgroundWarmupService.cs
+++ b/Baketa.Infrastructure/Services/BackgroundWarmupService.cs
@@ -188,21 +188,21 @@ public sealed class BackgroundWarmupService(
 
             var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
-            ReportProgress(0.0, "ウォームアップ開始", WarmupPhase.Starting);
+            ReportProgress(0.0, "Starting warmup", WarmupPhase.Starting);
 
             // フェーズ1: GPU環境検出（10%）
             await WarmupGpuEnvironmentAsync(cancellationToken).ConfigureAwait(false);
-            ReportProgress(0.1, "GPU環境検出完了", WarmupPhase.GpuDetection);
+            ReportProgress(0.1, "GPU environment detected", WarmupPhase.GpuDetection);
 
             // フェーズ2: OCRエンジン初期化とウォームアップ（50%）
             await WarmupOcrEnginesAsync(cancellationToken).ConfigureAwait(false);
             _isOcrWarmupCompleted = true;
-            ReportProgress(0.6, "OCRウォームアップ完了", WarmupPhase.OcrWarmup);
+            ReportProgress(0.6, "OCR warmup completed", WarmupPhase.OcrWarmup);
 
             // フェーズ3: 翻訳エンジン初期化とウォームアップ（40%）
             await WarmupTranslationEnginesAsync(cancellationToken).ConfigureAwait(false);
             _isTranslationWarmupCompleted = true;
-            ReportProgress(1.0, "全ウォームアップ完了", WarmupPhase.Completed);
+            ReportProgress(1.0, "All warmup completed", WarmupPhase.Completed);
 
             _isWarmupCompleted = true;
             stopwatch.Stop();
@@ -227,7 +227,7 @@ public sealed class BackgroundWarmupService(
             LastError = ex;
 
             _logger.LogError(ex, "ウォームアップ中にエラーが発生しました");
-            ReportProgress(_warmupProgress, $"エラー: {ex.Message}", WarmupPhase.Starting);
+            ReportProgress(_warmupProgress, $"Error: {ex.Message}", WarmupPhase.Starting);
             throw;
         }
     }
@@ -257,7 +257,7 @@ public sealed class BackgroundWarmupService(
     {
         try
         {
-            ReportProgress(0.2, "OCRエンジン初期化中", WarmupPhase.OcrInitialization);
+            ReportProgress(0.2, "Initializing OCR engine", WarmupPhase.OcrInitialization);
 
             // IOcrEngineサービスを取得
             var ocrEngine = _serviceProvider.GetService<IOcrEngine>();
@@ -280,7 +280,7 @@ public sealed class BackgroundWarmupService(
                 }
             }
 
-            ReportProgress(0.4, "OCRエンジンウォームアップ中", WarmupPhase.OcrWarmup);
+            ReportProgress(0.4, "Warming up OCR engine", WarmupPhase.OcrWarmup);
 
             // OCRエンジンウォームアップ
             var warmupSuccess = await ocrEngine.WarmupAsync(cancellationToken).ConfigureAwait(false);
@@ -305,7 +305,7 @@ public sealed class BackgroundWarmupService(
     {
         try
         {
-            ReportProgress(0.7, "翻訳エンジン初期化中", WarmupPhase.TranslationInitialization);
+            ReportProgress(0.7, "Initializing translation engine", WarmupPhase.TranslationInitialization);
 
             // ITranslationEngineサービスを取得（全ての実装をウォームアップ）
             var translationEngines = _serviceProvider.GetServices<ITranslationEngine>().ToList();
@@ -350,7 +350,7 @@ public sealed class BackgroundWarmupService(
                         }
 
                         ReportProgress(currentProgress + progressIncrement,
-                            $"{engine.Name}ウォームアップ完了", WarmupPhase.TranslationWarmup);
+                            $"{engine.Name} warmup completed", WarmupPhase.TranslationWarmup);
                     }
                     catch (Exception ex)
                     {

--- a/Baketa.UI/Views/ToastNotificationWindow.axaml.cs
+++ b/Baketa.UI/Views/ToastNotificationWindow.axaml.cs
@@ -89,13 +89,15 @@ public partial class ToastNotificationWindow : Window
             if (screen == null) return;
 
             var workingArea = screen.WorkingArea;
+            var scaling = screen.Scaling;
             const int margin = 16;
 
-            // 実際のウィンドウサイズを取得（レイアウト完了後なので正確）
-            var windowHeight = (int)Bounds.Height;
+            // 実際のウィンドウサイズを取得し、DPIスケーリングで物理ピクセルに変換
+            // Bounds.Height は論理ピクセル、WorkingArea は物理ピクセルのため変換が必要
+            var windowHeight = (int)(Bounds.Height * scaling);
             if (windowHeight <= 0)
             {
-                windowHeight = 100; // フォールバック値
+                windowHeight = (int)(100 * scaling); // フォールバック値
             }
 
             // [Issue #343] WorkingArea.X/Y を考慮（マルチモニター対応）

--- a/tests/Baketa.Application.Tests/Services/Translation/TranslationOrchestrationServiceTests.cs
+++ b/tests/Baketa.Application.Tests/Services/Translation/TranslationOrchestrationServiceTests.cs
@@ -90,6 +90,7 @@ public class TranslationOrchestrationServiceTests : IDisposable
             null, // fallbackOrchestrator（Issue #290: テスト用にnull）
             null, // licenseManager（Issue #290: テスト用にnull）
             null, // speculativeOcrService（Issue #293: テスト用にnull）
+            null, // windowManagerAdapter（Issue #389: テスト用にnull）
             _loggerMock.Object);
     }
 


### PR DESCRIPTION
## Summary

- **#389**: 対象ウィンドウクローズ時にUIを初期状態に完全リセット
- **#390**: ウォームアップ・初期化画面のステータステキストを英語化
- **#405**: トースト通知のDPIスケーリング補正
- **#406**: 翻訳オーバーレイのCJKテキスト文字単位折り返し

Closes #389
Closes #390
Closes #405
Closes #406

## Changes

### #389: 対象ウィンドウクローズ時のUIリセット
- `AdaptiveCaptureServiceAdapter`: キャプチャ全戦略失敗時に`GetWindowBounds()`でウィンドウ存在チェック → `CaptureFailedEvent`発行
- `MainOverlayViewModel`: `CaptureFailedEvent`ハンドラー追加。翻訳停止・オーバーレイ非表示・UI状態完全リセット（`IsTranslationActive`, `IsLoading`, `IsTranslationResultVisible`, `IsSingleshotOverlayVisible`, `SelectedWindow`, `IsWindowSelected`, `CurrentStatus`）
- `TranslationOrchestrationService`: `WindowClosed`結果を追加し翻訳ループ即時停止。キャプチャ前・後のウィンドウ存在チェック
- `WindowManagementService`: `ValidateWindowAsync()`に`GetWindowBounds()`による実在チェック実装

### #390: テキスト英語化
- `BackgroundWarmupService`: ウォームアップステータス文字列を日本語→英語
- `ApplicationInitializer`: 初期化ステータス文字列を日本語→英語

### #405: DPIスケーリング修正
- `ToastNotificationWindow`: `Bounds.Height`を`screen.Scaling`で物理ピクセルに変換

### #406: CJKテキスト折り返し
- `LayeredOverlayWindow`: CJK文字を含むテキストは文字単位で折り返す`WrapTextByCharacter()`を追加

## Test plan
- [x] ビルド成功確認（0エラー0警告）
- [ ] 翻訳中にウィンドウを閉じてUIが初期状態に戻ることを確認
- [ ] Shot翻訳中にウィンドウを閉じてUIが初期状態に戻ることを確認
- [ ] ウォームアップ画面のテキストが英語表示であることを確認
- [ ] 高DPI環境でトースト通知が画面内に表示されることを確認
- [ ] 日本語翻訳テキストがオーバーレイ内で折り返されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)