### PR TITLE
fix(#418,#419,#420,#422): Download progress i18n, README.ja.md, log cleanup, Surya timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,7 @@ jobs:
 
         # Copy additional files (Issue #268: Use user-friendly README for release package)
         Copy-Item "docs/release/README.md" "$publishDir/" -ErrorAction SilentlyContinue
+        Copy-Item "docs/release/README.ja.md" "$publishDir/" -ErrorAction SilentlyContinue
         Copy-Item "LICENSE" "$publishDir/" -ErrorAction SilentlyContinue
 
         # Create versioned zip (for appcast version extraction)

--- a/Baketa.Core/Performance/PerformanceLogger.cs
+++ b/Baketa.Core/Performance/PerformanceLogger.cs
@@ -17,13 +17,13 @@ public static class PerformanceLogger
     /// メインのパフォーマンス分析ログファイル
     /// </summary>
     public static readonly string MainLogPath = Path.Combine(
-        AppDomain.CurrentDomain.BaseDirectory, "performance_analysis.log");
+        AppDomain.CurrentDomain.BaseDirectory, "Logs", "performance_analysis.log");
 
     /// <summary>
     /// デバッグ情報用のログファイル
     /// </summary>
     public static readonly string DebugLogPath = Path.Combine(
-        AppDomain.CurrentDomain.BaseDirectory, "debug_detailed.log");
+        AppDomain.CurrentDomain.BaseDirectory, "Logs", "debug_detailed.log");
 
     /// <summary>
     /// 旧ログファイルパス（クリーンアップ用）
@@ -57,9 +57,11 @@ public static class PerformanceLogger
         {
             if (_initialized) return;
 
-            // 新しいログファイルを初期化
+#if DEBUG
+            // 新しいログファイルを初期化（DEBUGビルドのみ）
             InitializeLogFile(MainLogPath, "PERFORMANCE ANALYSIS");
             InitializeLogFile(DebugLogPath, "DEBUG DETAILED LOG");
+#endif
 
             // 既存の分散ログファイルをクリーンアップ（オプション）
             CleanupObsoleteLogs();
@@ -77,11 +79,10 @@ public static class PerformanceLogger
     {
         var timestampedMessage = $"[{DateTime.Now:HH:mm:ss.fff}] {message}";
 
+#if DEBUG
         WriteToFile(MainLogPath, timestampedMessage);
+#endif
         Console.WriteLine(timestampedMessage);
-
-        // 従来のDebugLogUtility互換性も提供
-        Console.WriteLine(message);
     }
 
     /// <summary>
@@ -89,8 +90,10 @@ public static class PerformanceLogger
     /// </summary>
     public static void LogDebug(string message)
     {
+#if DEBUG
         var timestampedMessage = $"[{DateTime.Now:HH:mm:ss.fff}] {message}";
         WriteToFile(DebugLogPath, timestampedMessage);
+#endif
     }
 
     /// <summary>
@@ -103,7 +106,9 @@ public static class PerformanceLogger
 
         var fullSummary = $"\n{separator}\n{summary}\n{separator}\n";
 
+#if DEBUG
         WriteToFile(MainLogPath, fullSummary);
+#endif
         Console.WriteLine(fullSummary);
     }
 
@@ -164,6 +169,8 @@ public static class PerformanceLogger
     {
         try
         {
+            var dir = Path.GetDirectoryName(logPath);
+            if (dir != null) Directory.CreateDirectory(dir);
             var initMessage = $"=== {header} - Started at {DateTime.Now:yyyy-MM-dd HH:mm:ss} ===\n";
             File.WriteAllText(logPath, initMessage);
         }
@@ -177,6 +184,8 @@ public static class PerformanceLogger
     {
         try
         {
+            var dir = Path.GetDirectoryName(filePath);
+            if (dir != null) Directory.CreateDirectory(dir);
             lock (LogLock)
             {
                 File.AppendAllText(filePath, message + Environment.NewLine);

--- a/Baketa.Core/Performance/PerformanceMeasurement.cs
+++ b/Baketa.Core/Performance/PerformanceMeasurement.cs
@@ -75,7 +75,7 @@ public sealed record PerformanceMeasurementResult
 public sealed class PerformanceMeasurement : IDisposable
 {
     private static readonly string LogFilePath = Path.Combine(
-        AppDomain.CurrentDomain.BaseDirectory, "performance_analysis.log");
+        AppDomain.CurrentDomain.BaseDirectory, "Logs", "performance_analysis.log");
 
     private static readonly ConcurrentQueue<PerformanceMeasurementResult> Results = new();
     private static readonly object FileLock = new();
@@ -262,8 +262,11 @@ public sealed class PerformanceMeasurement : IDisposable
 
     private static void WriteToFile(string message)
     {
+#if DEBUG
         try
         {
+            var dir = Path.GetDirectoryName(LogFilePath);
+            if (dir != null) Directory.CreateDirectory(dir);
             lock (FileLock)
             {
                 File.AppendAllText(LogFilePath, message + Environment.NewLine);
@@ -273,6 +276,7 @@ public sealed class PerformanceMeasurement : IDisposable
         {
             // ファイル書き込みエラーは無視
         }
+#endif
     }
 
     private static void WriteToConsole(string message)

--- a/Baketa.Core/Settings/LoggingSettings.cs
+++ b/Baketa.Core/Settings/LoggingSettings.cs
@@ -17,7 +17,7 @@ public sealed record LoggingSettings
     /// </summary>
     [Display(Name = "デバッグログパス", Description = "デバッグ用ログファイルの出力パス")]
     [Required(ErrorMessage = "デバッグログパスは必須です")]
-    public string DebugLogPath { get; init; } = "debug_app_logs.txt";
+    public string DebugLogPath { get; init; } = Path.Combine("Logs", "debug_app_logs.txt");
 
     /// <summary>
     /// デバッグファイルログの有効性
@@ -48,7 +48,7 @@ public sealed record LoggingSettings
     /// Stage 2 ノイズフィルタの判定データを収集
     /// </summary>
     [Display(Name = "テレメトリログパス", Description = "テレメトリデータ収集用ログファイルの出力パス")]
-    public string TelemetryLogPath { get; init; } = "telemetry_stage2.csv";
+    public string TelemetryLogPath { get; init; } = Path.Combine("Logs", "telemetry_stage2.csv");
 
     /// <summary>
     /// [Issue #229] テレメトリログの有効性
@@ -123,7 +123,7 @@ public sealed record LoggingSettings
     /// <returns>開発設定</returns>
     public static LoggingSettings CreateDevelopmentSettings() => new()
     {
-        DebugLogPath = "dev_debug_logs.txt",
+        DebugLogPath = Path.Combine("Logs", "dev_debug_logs.txt"),
         EnableDebugFileLogging = true,
         MaxDebugLogFileSizeMB = 50, // 開発時は大きなサイズを許可
         DebugLogRetentionDays = 14 // 長い保持期間

--- a/Baketa.Infrastructure/OCR/Services/SuryaServerManager.cs
+++ b/Baketa.Infrastructure/OCR/Services/SuryaServerManager.cs
@@ -104,6 +104,18 @@ public sealed class SuryaServerManager : IOcrServerManager
         if (_isUnifiedMode)
         {
             var timeoutSeconds = _unifiedServerSettings?.StartupTimeoutSeconds ?? 300;
+
+            // [Issue #422] 統合サーバーexe未検出時はダウンロード/展開中と判断しタイムアウトを延長
+            var unifiedExePath = Path.Combine(AppContext.BaseDirectory,
+                "grpc_server", "BaketaUnifiedServer", "BaketaUnifiedServer.exe");
+            if (!File.Exists(unifiedExePath))
+            {
+                var extendedTimeout = Math.Max(timeoutSeconds, 600);
+                _logger.LogInformation("⏳ [Issue #422] [Surya] 統合サーバーexe未検出 → ダウンロード/展開中と判断、タイムアウトを{Original}秒→{Extended}秒に延長",
+                    timeoutSeconds, extendedTimeout);
+                timeoutSeconds = extendedTimeout;
+            }
+
             _logger.LogInformation("🔄 [Issue #292] [Surya] 統合サーバーモード - gRPCポーリングで準備完了を待機中... Port {Port}, Timeout {Timeout}秒",
                 _port, timeoutSeconds);
 

--- a/Baketa.Infrastructure/Services/Setup/ComponentDownloadService.cs
+++ b/Baketa.Infrastructure/Services/Setup/ComponentDownloadService.cs
@@ -263,7 +263,7 @@ public class ComponentDownloadService : IComponentDownloader
                     component.ExpectedSizeBytes,
                     0,
                     isCompleted: false,
-                    statusMessage: $"{component.DisplayName} を展開しています... (数分かかる場合があります)");
+                    statusMessage: $"Extracting {component.DisplayName}... (this may take a few minutes)");
 
                 // Extract to destination with error handling
                 try
@@ -279,8 +279,8 @@ public class ComponentDownloadService : IComponentDownloader
                         component.ExpectedSizeBytes,
                         0,
                         isCompleted: false,
-                        errorMessage: $"展開に失敗しました: {ex.Message}",
-                        statusMessage: "エラー: 展開に失敗しました");
+                        errorMessage: $"Extraction failed: {ex.Message}",
+                        statusMessage: "Error: Extraction failed");
                     throw;
                 }
 
@@ -424,7 +424,7 @@ public class ComponentDownloadService : IComponentDownloader
         await Task.WhenAll(downloadTasks).ConfigureAwait(false);
 
         totalStopwatch.Stop();
-        _logger.LogInformation("[Gemini Review] Downloaded {SuccessCount}/{TotalCount} components in {ElapsedMs}ms (並列数: {Concurrency})",
+        _logger.LogInformation("[Gemini Review] Downloaded {SuccessCount}/{TotalCount} components in {ElapsedMs}ms (Concurrency: {Concurrency})",
             downloadCount, missingComponents.Count, totalStopwatch.ElapsedMilliseconds, maxConcurrentDownloads);
 
         // [Gemini Review] 部分的失敗の場合、エラーをログに出力
@@ -753,7 +753,7 @@ public class ComponentDownloadService : IComponentDownloader
                     component.ExpectedSizeBytes,
                     0,
                     isCompleted: false,
-                    statusMessage: $"{component.DisplayName} をダウンロード中... (パート {i}/{component.SplitParts})");
+                    statusMessage: $"Downloading {component.DisplayName}... (Part {i}/{component.SplitParts})");
 
                 // Download this part
                 using var response = await _httpClient.GetAsync(
@@ -800,7 +800,7 @@ public class ComponentDownloadService : IComponentDownloader
                             component.ExpectedSizeBytes,
                             speed,
                             isCompleted: false,
-                            statusMessage: $"{component.DisplayName} をダウンロード中... (パート {i}/{component.SplitParts}, {progressPercent:F1}%)");
+                            statusMessage: $"Downloading {component.DisplayName}... (Part {i}/{component.SplitParts}, {progressPercent:F1}%)");
 
                         lastBytesForSpeed = partBytesReceived;
                         lastReportTime.Restart();
@@ -824,7 +824,7 @@ public class ComponentDownloadService : IComponentDownloader
                             component.ExpectedSizeBytes,
                             0,
                             isCompleted: false,
-                            statusMessage: $"{component.DisplayName} パート {i} を検証中...");
+                            statusMessage: $"Verifying {component.DisplayName} Part {i}...");
 
                         // Need to close fileStream before computing checksum
                         await fileStream.DisposeAsync().ConfigureAwait(false);
@@ -875,7 +875,7 @@ public class ComponentDownloadService : IComponentDownloader
                             component.ExpectedSizeBytes,
                             0,
                             isCompleted: false,
-                            statusMessage: $"{component.DisplayName} を結合しています... ({concatPercent:F1}%)");
+                            statusMessage: $"Concatenating {component.DisplayName}... ({concatPercent:F1}%)");
                         lastConcatReportTime.Restart();
                     }
                 }
@@ -936,7 +936,7 @@ public class ComponentDownloadService : IComponentDownloader
             {
                 var requiredMB = requiredBytes / (1024 * 1024);
                 var availableMB = tempDrive.AvailableFreeSpace / (1024 * 1024);
-                var splitInfo = component.SplitParts > 1 ? $" ({component.SplitParts}パート分割)" : "";
+                var splitInfo = component.SplitParts > 1 ? $" ({component.SplitParts} parts)" : "";
                 var message = $"Insufficient disk space on drive ({tempDrive.Name}){splitInfo}. " +
                              $"Required: {requiredMB:N0} MB (download + extraction), Available: {availableMB:N0} MB";
                 _logger.LogError(message);
@@ -957,7 +957,7 @@ public class ComponentDownloadService : IComponentDownloader
             {
                 var requiredMB = tempRequiredBytes / (1024 * 1024);
                 var availableMB = tempDrive.AvailableFreeSpace / (1024 * 1024);
-                var splitInfo = component.SplitParts > 1 ? $" ({component.SplitParts}パート分割)" : "";
+                var splitInfo = component.SplitParts > 1 ? $" ({component.SplitParts} parts)" : "";
                 var message = $"Insufficient disk space on temp drive ({tempDrive.Name}){splitInfo}. " +
                              $"Required: {requiredMB:N0} MB, Available: {availableMB:N0} MB";
                 _logger.LogError(message);

--- a/Baketa.UI/appsettings.json
+++ b/Baketa.UI/appsettings.json
@@ -11,7 +11,7 @@
       "Baketa.Application.Services": "Information",
       "Baketa.UI.ViewModels": "Warning"
     },
-    "DebugLogPath": "debug_app_logs.txt",
+    "DebugLogPath": "Logs/debug_app_logs.txt",
     "EnableDebugFileLogging": false,
     "MaxDebugLogFileSizeMB": 10,
     "DebugLogRetentionDays": 7


### PR DESCRIPTION
## Summary
- **#418**: Translate remaining Japanese status messages in ComponentDownloadService to English
- **#419**: Add README.ja.md to release package in release.yml
- **#420**: Suppress performance/debug log file output in Release builds (#if DEBUG), redirect all log paths to Logs/ subdirectory
- **#422**: Extend SuryaServerManager unified server mode timeout from 300s to 600s when exe is not found (download/extraction in progress)

## Test plan
- [ ] Build succeeds with 0 errors, 0 warnings
- [ ] Release build does not create log files in app root directory
- [ ] Debug build creates log files under Logs/ subdirectory
- [ ] Download progress messages display in English
- [ ] First-time startup: SuryaServerManager waits up to 600s for unified server download

Closes #418, #419, #420, #422