### PR TITLE
feat(#427,#429): Cloud翻訳の翻訳履歴インジェクション + 信頼度スコア + OCR配置ヒント

### DIFF
--- a/Baketa.Core/Translation/Models/ImageTranslationRequest.cs
+++ b/Baketa.Core/Translation/Models/ImageTranslationRequest.cs
@@ -1,3 +1,5 @@
+using Baketa.Core.Models;
+
 namespace Baketa.Core.Translation.Abstractions;
 
 /// <summary>
@@ -46,6 +48,18 @@ public sealed class ImageTranslationRequest
     public string? Context { get; init; }
 
     /// <summary>
+    /// [Issue #427] 翻訳履歴（文脈維持用）
+    /// 直近の翻訳結果を含め、口調・固有名詞の一貫性を維持する
+    /// </summary>
+    public IReadOnlyList<TranslationHistoryEntry>? TranslationHistory { get; init; }
+
+    /// <summary>
+    /// [Issue #429] OCR配置ヒント（軽量版）
+    /// Surya Detectionで検出済みのテキスト領域情報をCloud翻訳に伝達
+    /// </summary>
+    public OcrHints? OcrHints { get; init; }
+
+    /// <summary>
     /// セッショントークン（認証用）
     /// </summary>
     public required string SessionToken { get; init; }
@@ -73,4 +87,28 @@ public sealed class ImageTranslationRequest
             Context = context
         };
     }
+}
+
+/// <summary>
+/// [Issue #427] 翻訳履歴エントリ
+/// </summary>
+public sealed record TranslationHistoryEntry
+{
+    /// <summary>原文テキスト</summary>
+    public required string Original { get; init; }
+
+    /// <summary>訳文テキスト</summary>
+    public required string Translation { get; init; }
+}
+
+/// <summary>
+/// [Issue #429] OCR配置ヒント（軽量版）
+/// </summary>
+public sealed record OcrHints
+{
+    /// <summary>検出されたテキスト領域の数</summary>
+    public int TextRegionCount { get; init; }
+
+    /// <summary>テキスト領域の大まかな位置（Top/Center/Bottom）</summary>
+    public IReadOnlyList<string> TextAreas { get; init; } = [];
 }

--- a/Baketa.Core/Translation/Models/ImageTranslationResponse.cs
+++ b/Baketa.Core/Translation/Models/ImageTranslationResponse.cs
@@ -181,6 +181,12 @@ public sealed class TranslatedTextItem
     /// バウンディングボックスが設定されているか
     /// </summary>
     public bool HasBoundingBox => BoundingBox.HasValue;
+
+    /// <summary>
+    /// [Issue #429] 翻訳の信頼度スコア（0.0〜1.0）
+    /// AIによる自己評価。低スコアの翻訳はフィルタリング対象
+    /// </summary>
+    public float? ConfidenceScore { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
- **#427**: Cloud翻訳リクエストに直近5件の翻訳履歴を注入し、口調・固有名詞の一貫性を向上
- **#429**: AIによるconfidence_score返却で低品質翻訳を自動フィルタリング + 前回サイクルのOCR結果をヒントとしてCloud AIに注入

## 変更内容

### #427 翻訳履歴インジェクション
- `ConcurrentDictionary<IntPtr, List<TranslationHistoryEntry>>` でウィンドウ単位にスレッドセーフ管理
- Gemini/OpenAI両プロバイダーのプロンプトに `# Translation History` セクション注入
- ゲーム切替・翻訳停止時に履歴クリア

### #429 信頼度スコア + OCR配置ヒント
- Gemini `response_schema` に `confidence_score` 追加、OpenAIはプロンプト指示
- 0.70未満の低品質翻訳を自動フィルタリング
- 前回サイクルのOCRヒントキャッシュ方式（Fork-Joinの並列性を維持しつつヒント提供）
- 画面3分割（Top/Center/Bottom）の軽量エリア分類

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `Baketa.Core/.../ImageTranslationRequest.cs` | `TranslationHistory`, `OcrHints` モデル追加 |
| `Baketa.Core/.../ImageTranslationResponse.cs` | `ConfidenceScore` 追加 |
| `Baketa.Infrastructure/.../RelayServerClient.cs` | リクエスト/レスポンスマッピング拡張 |
| `Baketa.Application/.../CoordinateBasedTranslationService.cs` | 履歴バッファ、OCRヒントキャッシュ、注入ロジック |
| `relay-server/src/translate.ts` | Gemini/OpenAI プロンプト・スキーマ拡張 |

## Test plan
- [x] ビルド成功（0警告、0エラー）
- [x] Core 810/810、Application 165/165 テストパス
- [x] 翻訳履歴の蓄積確認（1→2→3→4件）
- [x] confidence_scoreによるフィルタリング動作確認（0.70未満1件除外）
- [x] OCR配置ヒント注入確認（13領域, Areas=[Center, Bottom]）
- [x] Relay Server デプロイ済み・動作確認済み

Closes #427, Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)