### PR TITLE
fix(#461): トークンクリア追跡ログ追加

### DIFF
--- a/Baketa.Infrastructure/Auth/SupabaseAuthService.cs
+++ b/Baketa.Infrastructure/Auth/SupabaseAuthService.cs
@@ -481,14 +481,14 @@ public sealed class SupabaseAuthService : IAuthService, IDisposable
             }
             else
             {
-                _logger.LogWarning("Session restoration returned no valid session, clearing stored tokens");
+                _logger.LogWarning("[TOKEN_CLEAR][Path-3A] SupabaseAuthService.RestoreSessionAsync: SetSession returned null/no user — clearing stored tokens");
                 await _tokenStorage.ClearTokensAsync(cancellationToken).ConfigureAwait(false);
                 AuthStatusChanged?.Invoke(this, new AuthStatusChangedEventArgs(false, null, false));
             }
         }
         catch (GotrueException ex)
         {
-            _logger.LogWarning(ex, "Session restoration failed (invalid/expired tokens), clearing stored tokens");
+            _logger.LogWarning(ex, "[TOKEN_CLEAR][Path-3B] SupabaseAuthService.RestoreSessionAsync: GotrueException (invalid/expired tokens) — clearing stored tokens. Message={Message}", ex.Message);
             await _tokenStorage.ClearTokensAsync(cancellationToken).ConfigureAwait(false);
             AuthStatusChanged?.Invoke(this, new AuthStatusChangedEventArgs(false, null, false));
         }
@@ -521,8 +521,9 @@ public sealed class SupabaseAuthService : IAuthService, IDisposable
             await _supabaseClient.Auth.SignOut().ConfigureAwait(false);
 
             // Clear stored tokens from persistent storage
+            _logger.LogInformation("[TOKEN_CLEAR][Path-3C] SupabaseAuthService.SignOutAsync: Normal signout flow — clearing stored tokens");
             await _tokenStorage.ClearTokensAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogDebug("Cleared stored tokens");
+            _logger.LogDebug("[TOKEN_CLEAR][Path-3C] Cleared stored tokens");
 
             _logger.LogInformation("User signout completed");
             AuthStatusChanged?.Invoke(this, new AuthStatusChangedEventArgs(false, null, true));
@@ -536,6 +537,7 @@ public sealed class SupabaseAuthService : IAuthService, IDisposable
         {
             _logger.LogError(ex, "Error during signout");
             // Even if signout fails on server, clear local state and tokens
+            _logger.LogWarning("[TOKEN_CLEAR][Path-3D] SupabaseAuthService.SignOutAsync: Error recovery — clearing stored tokens. Error={Error}", ex.Message);
             await _tokenStorage.ClearTokensAsync(CancellationToken.None).ConfigureAwait(false);
             AuthStatusChanged?.Invoke(this, new AuthStatusChangedEventArgs(false, null, true));
         }

--- a/Baketa.Infrastructure/Auth/TokenExpirationHandler.cs
+++ b/Baketa.Infrastructure/Auth/TokenExpirationHandler.cs
@@ -76,14 +76,15 @@ public sealed class TokenExpirationHandler : ITokenExpirationHandler, IDisposabl
                 }
 
                 // 3. ローカルトークンを削除
+                _logger.LogWarning("[TOKEN_CLEAR][Path-1A] Infrastructure.TokenExpirationHandler: HandleTokenExpiredAsync normal flow. Reason={Reason}, UserId={UserId}", reason, MaskUserId(userId));
                 var cleared = await _tokenStorage.ClearTokensAsync(cancellationToken).ConfigureAwait(false);
                 if (cleared)
                 {
-                    _logger.LogInformation("Local tokens cleared successfully");
+                    _logger.LogInformation("[TOKEN_CLEAR][Path-1A] Local tokens cleared successfully");
                 }
                 else
                 {
-                    _logger.LogWarning("Failed to clear local tokens or no tokens existed");
+                    _logger.LogWarning("[TOKEN_CLEAR][Path-1A] Failed to clear local tokens or no tokens existed");
                 }
 
                 // 4. イベント発火（UI層でハンドリング）
@@ -107,11 +108,12 @@ public sealed class TokenExpirationHandler : ITokenExpirationHandler, IDisposabl
                 // エラーが発生してもトークンは確実に削除
                 try
                 {
+                    _logger.LogWarning("[TOKEN_CLEAR][Path-1B] Infrastructure.TokenExpirationHandler: Error recovery in HandleTokenExpiredAsync. OriginalReason={Reason}, Error={Error}", reason, ex.Message);
                     await _tokenStorage.ClearTokensAsync(CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception clearEx)
                 {
-                    _logger.LogError(clearEx, "Failed to clear tokens during error recovery");
+                    _logger.LogError(clearEx, "[TOKEN_CLEAR][Path-1B] Failed to clear tokens during error recovery");
                 }
 
                 // エラー時もイベントは発火（UI側で適切に処理させる）

--- a/Baketa.UI/App.axaml.cs
+++ b/Baketa.UI/App.axaml.cs
@@ -488,8 +488,9 @@ internal sealed partial class App : Avalonia.Application, IDisposable
                             // セキュリティ強化: 不正なトークンを削除
                             try
                             {
+                                _logger?.LogWarning("[TOKEN_CLEAR][Path-5] App.axaml.cs: GetCurrentSessionAsync failed during startup — clearing stored tokens. Error={Error}", authEx.Message);
                                 await tokenStorage.ClearTokensAsync().ConfigureAwait(true);
-                                _logger?.LogInformation("セッション復元失敗に伴い、保存されたトークンをクリアしました");
+                                _logger?.LogInformation("[TOKEN_CLEAR][Path-5] セッション復元失敗に伴い、保存されたトークンをクリアしました");
                             }
                             catch (Exception clearEx)
                             {

--- a/Baketa.UI/Services/TokenExpirationHandler.cs
+++ b/Baketa.UI/Services/TokenExpirationHandler.cs
@@ -95,12 +95,14 @@ public sealed class TokenExpirationHandler : IDisposable
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             // 3. Clear local tokens
+            _logger.LogWarning("[TOKEN_CLEAR][Path-2A] UI.TokenExpirationHandler: HandleTokenExpiredAsync. Reason={Reason}, UserId={UserId}", reason, userId);
             await _tokenStorage.ClearTokensAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogInformation("Local tokens cleared");
+            _logger.LogInformation("[TOKEN_CLEAR][Path-2A] Local tokens cleared");
 
-            // 4. Sign out from Supabase
+            // 4. Sign out from Supabase (注意: SignOutAsync内でも ClearTokensAsync が呼ばれる = Path-3C/3D)
             try
             {
+                _logger.LogWarning("[TOKEN_CLEAR][Path-2B] UI.TokenExpirationHandler: Calling SignOutAsync (will trigger Path-3C/3D)");
                 await _authService.SignOutAsync(cancellationToken).ConfigureAwait(false);
                 _logger.LogInformation("Signed out from authentication service");
             }


### PR DESCRIPTION
## Summary
- 再ログイン問題(#461)の原因特定のため、ClearTokensAsync呼び出し全9箇所に `[TOKEN_CLEAR][Path-XX]` タグ付きWarningログを追加
- WindowsCredentialStorage にスタックトレース記録を追加（パフォーマンスガード付き）
- 正常サインアウト(Path-3C)は Information レベルで記録（Geminiレビュー反映）

## 変更ファイル (5ファイル)
| ファイル | パスID | トリガー |
|---------|--------|---------|
| `WindowsCredentialStorage.cs` | 共通 | StackTrace付きで全呼び出し元を記録 |
| `Infrastructure/Auth/TokenExpirationHandler.cs` | 1A, 1B | HTTP 401 / セッション期限切れ |
| `UI/Services/TokenExpirationHandler.cs` | 2A, 2B | TokenRefreshService失敗 → SignOut連鎖 |
| `Infrastructure/Auth/SupabaseAuthService.cs` | 3A~3D | RestoreSession失敗 / SignOut |
| `UI/App.axaml.cs` | 5 | 起動時セッション復元例外 |

## 使い方
次回再ログインが発生した時、ログファイルで `TOKEN_CLEAR` を検索するだけで原因パスを特定可能。

## Test plan
- [x] `dotnet build` — 0エラー、0警告
- [x] `dotnet test` — 1,833+ テスト全パス
- [x] Gemini コードレビュー実施・指摘反映済み

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)