### PR TITLE
fix(#491): CJK1文字Gate通過許可+OCR不検出ベースのオーバーレイ自動クリア

### DIFF
--- a/Baketa.Application/EventHandlers/Translation/AggregatedChunksReadyEventHandler.cs
+++ b/Baketa.Application/EventHandlers/Translation/AggregatedChunksReadyEventHandler.cs
@@ -84,6 +84,14 @@ public sealed partial class AggregatedChunksReadyEventHandler : IEventProcessor<
     // [Issue #414] ファジーテキストマッチング（Cloud結果のあいまい一致検証用）
     private readonly IFuzzyTextMatcher? _fuzzyTextMatcher;
 
+    // [Issue #491] OCR不検出ベースのオーバーレイ自動クリア
+    // 前サイクルでOCRがテキストを検出したゾーンのセット
+    private HashSet<string> _previousCycleZones = [];
+    // ゾーンごとの連続不検出カウンター
+    private readonly ConcurrentDictionary<string, int> _zoneAbsenceCounter = new();
+    // 不検出と判定する連続サイクル数
+    private const int OcrAbsenceThreshold = 3;
+
     public AggregatedChunksReadyEventHandler(
         Baketa.Core.Abstractions.Translation.ITranslationService translationService,
         // 🔧 [OVERLAY_UNIFICATION] IInPlaceTranslationOverlayManager → IOverlayManager に統一
@@ -2479,6 +2487,9 @@ public sealed partial class AggregatedChunksReadyEventHandler : IEventProcessor<
                 regionInfo = heatmapValue.HasValue
                     ? GateRegionInfo.WithHeatmap(normalizedX, normalizedY, normalizedWidth, normalizedHeight, heatmapValue.Value)
                     : GateRegionInfo.FromCoordinates(normalizedX, normalizedY, normalizedWidth, normalizedHeight);
+
+                // [Issue #491] OCR信頼度をGateRegionInfoに設定（CJK1文字Gate判定に使用）
+                regionInfo = regionInfo with { ConfidenceScore = (float)chunk.AverageConfidence };
             }
 
             // Gate判定を実行（代表チャンクのみ）
@@ -2531,7 +2542,127 @@ public sealed partial class AggregatedChunksReadyEventHandler : IEventProcessor<
                 gatePassedCount, gateBlockedCount, roiEnabled, evaluatedZones.Count);
         }
 
+        // [Issue #491] OCR不検出ベースのオーバーレイ自動クリア
+        var sourceWindowHandle = chunks.FirstOrDefault()?.SourceWindowHandle ?? IntPtr.Zero;
+        await ProcessOcrAbsenceCleanupAsync(
+            evaluatedZones, imageWidth, imageHeight, sourceWindowHandle, cancellationToken).ConfigureAwait(false);
+
         return gatedChunks;
+    }
+
+    /// <summary>
+    /// [Issue #491] OCR不検出ベースのオーバーレイ自動クリア
+    /// </summary>
+    /// <remarks>
+    /// 前回のOCRサイクルでテキストが検出されたゾーンのうち、今回検出されなかったゾーンの
+    /// 不検出カウンターをインクリメント。連続OcrAbsenceThresholdサイクル不検出で
+    /// TextDisappearanceEventを発行してオーバーレイを削除。
+    /// evaluatedZonesはGate-BLOCKEDゾーンも含むため、OCRで検出されたゾーン全体を追跡できる。
+    /// </remarks>
+    private async Task ProcessOcrAbsenceCleanupAsync(
+        HashSet<string> currentCycleZones,
+        int imageWidth,
+        int imageHeight,
+        IntPtr sourceWindowHandle,
+        CancellationToken cancellationToken)
+    {
+        // 前回存在→今回不存在のゾーンを特定
+        var disappearedZones = _previousCycleZones.Except(currentCycleZones).ToList();
+        var zonesToClear = new List<string>();
+
+        foreach (var zoneId in disappearedZones)
+        {
+            var count = _zoneAbsenceCounter.AddOrUpdate(zoneId, 1, (_, c) => c + 1);
+            if (count >= OcrAbsenceThreshold)
+            {
+                zonesToClear.Add(zoneId);
+                _zoneAbsenceCounter.TryRemove(zoneId, out _);
+            }
+            else
+            {
+                _logger?.LogDebug(
+                    "[Issue #491] OCR不検出カウント: Zone={Zone}, Count={Count}/{Threshold}",
+                    zoneId, count, OcrAbsenceThreshold);
+            }
+        }
+
+        // 今回検出されたゾーンの不検出カウンターをリセット
+        foreach (var zoneId in currentCycleZones)
+        {
+            _zoneAbsenceCounter.TryRemove(zoneId, out _);
+        }
+
+        // 前回ゾーンを更新
+        _previousCycleZones = [.. currentCycleZones];
+
+        // 連続不検出ゾーンのオーバーレイをクリア
+        if (zonesToClear.Count > 0)
+        {
+            _logger?.LogInformation(
+                "[Issue #491] OCR不検出によるオーバーレイクリア: Zones={Zones}",
+                string.Join(", ", zonesToClear));
+            Console.WriteLine($"🧹 [Issue #491] OCR不検出クリア: {string.Join(", ", zonesToClear)}");
+
+            // Gate状態をクリアして再検出時にFirstTextとして扱われるようにする
+            foreach (var zoneId in zonesToClear)
+            {
+                _textChangeDetectionService?.ClearPreviousText(zoneId);
+            }
+
+            // ゾーンIDからキャプチャ画像座標の矩形を計算してTextDisappearanceEventを発行
+            var stableWidth = imageWidth > 0 ? imageWidth : 1920;
+            var stableHeight = imageHeight > 0 ? imageHeight : 1080;
+            var regions = ConvertZonesToRectangles(zonesToClear, stableWidth, stableHeight);
+
+            if (regions.Count > 0)
+            {
+                var disappearanceEvent = new Baketa.Core.Events.Capture.TextDisappearanceEvent(
+                    regions,
+                    sourceWindow: sourceWindowHandle,
+                    regionId: "ocr_absence_cleanup",
+                    confidenceScore: 1.0f,
+                    captureImageSize: new System.Drawing.Size(stableWidth, stableHeight));
+
+                try
+                {
+                    await _eventAggregator.PublishAsync(disappearanceEvent, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex,
+                        "[Issue #491] TextDisappearanceEvent発行エラー: {Message}", ex.Message);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// [Issue #491] ゾーンIDリストからキャプチャ座標系の矩形リストに変換
+    /// </summary>
+    private static List<System.Drawing.Rectangle> ConvertZonesToRectangles(
+        List<string> zoneIds, int imageWidth, int imageHeight)
+    {
+        const int zoneColumns = 8;
+        const int zoneRows = 6;
+        var zoneWidth = imageWidth / zoneColumns;
+        var zoneHeight = imageHeight / zoneRows;
+        var rectangles = new List<System.Drawing.Rectangle>();
+
+        foreach (var zoneId in zoneIds)
+        {
+            // "zone_{row}_{col}" 形式を解析
+            var parts = zoneId.Split('_');
+            if (parts.Length == 3
+                && int.TryParse(parts[1], out var row)
+                && int.TryParse(parts[2], out var col))
+            {
+                rectangles.Add(new System.Drawing.Rectangle(
+                    col * zoneWidth, row * zoneHeight, zoneWidth, zoneHeight));
+            }
+        }
+
+        return rectangles;
     }
 
     // [Issue #482] HTML/LaTeXマークアップ検出用正規表現

--- a/Baketa.Core/Settings/RoiGatekeeperSettings.cs
+++ b/Baketa.Core/Settings/RoiGatekeeperSettings.cs
@@ -135,6 +135,30 @@ public sealed record RoiGatekeeperSettings
     public int MinTextLength { get; init; } = 2;
 
     // ========================================
+    // [Issue #491] CJK1文字テキスト許容設定
+    // ========================================
+
+    /// <summary>
+    /// CJK1文字テキストのGate通過を許可
+    /// </summary>
+    /// <remarks>
+    /// CJK文字（漢字・ひらがな・カタカナ等）1文字のテキストは、
+    /// 信頼度がCjkSingleCharConfidenceThreshold以上の場合にMinTextLengthを無視してGate通過を許可。
+    /// ゲームのキャラクター名（瞳、蛍、翠、薫等）の翻訳を可能にする。
+    /// デフォルト: true
+    /// </remarks>
+    public bool EnableCjkSingleCharPass { get; init; } = true;
+
+    /// <summary>
+    /// CJK1文字テキストのGate通過に必要な最小OCR信頼度
+    /// </summary>
+    /// <remarks>
+    /// 高い信頼度を要求することで、ノイズによる誤検出を防止。
+    /// デフォルト: 0.90（90%以上）
+    /// </remarks>
+    public float CjkSingleCharConfidenceThreshold { get; init; } = 0.90f;
+
+    // ========================================
     // 統計設定
     // ========================================
 
@@ -331,7 +355,9 @@ public sealed record RoiGatekeeperSettings
             && TypewriterStabilizationCycles >= 1
             && TypewriterMaxDelayCycles >= 1
             // [Issue #465] 静的UI要素検出の検証
-            && StaticUiDetectionThreshold >= 1;
+            && StaticUiDetectionThreshold >= 1
+            // [Issue #491] CJK1文字許容の検証
+            && CjkSingleCharConfidenceThreshold is >= 0.0f and <= 1.0f;
     }
 
     /// <summary>

--- a/Baketa.Infrastructure/Text/ChangeDetection/TextChangeDetectionService.cs
+++ b/Baketa.Infrastructure/Text/ChangeDetection/TextChangeDetectionService.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Baketa.Core.Abstractions.Processing;
 using Baketa.Core.Abstractions.Text;
@@ -153,18 +154,32 @@ public partial class TextChangeDetectionService : ITextChangeDetectionService
                     stopwatch.Elapsed);
             }
 
-            // 最小文字数チェック
+            // 最小文字数チェック（[Issue #491] CJK1文字例外付き）
             if (currentText.Length < _settings.MinTextLength)
             {
-                _logger.LogDebug(
-                    "[Issue #293] Text too short ({Length} < {Min}), skipping - SourceId: {SourceId}",
-                    currentText.Length, _settings.MinTextLength, sourceId);
+                // [Issue #491] CJK1文字テキストの特例: 高信頼度CJK文字はGate通過許可
+                if (_settings.EnableCjkSingleCharPass
+                    && currentText.Length == 1
+                    && IsCjkCharacter(currentText[0])
+                    && regionInfo?.ConfidenceScore >= _settings.CjkSingleCharConfidenceThreshold)
+                {
+                    _logger.LogInformation(
+                        "[Issue #491] CJK single char Gate pass: '{Text}' (Confidence={Confidence:F3}, Threshold={Threshold:F2}) - SourceId: {SourceId}",
+                        currentText, regionInfo.ConfidenceScore, _settings.CjkSingleCharConfidenceThreshold, sourceId);
+                    // MinTextLengthチェックをスキップして通常のGate評価に進む
+                }
+                else
+                {
+                    _logger.LogDebug(
+                        "[Issue #293] Text too short ({Length} < {Min}), skipping - SourceId: {SourceId}",
+                        currentText.Length, _settings.MinTextLength, sourceId);
 
-                return TextChangeWithGateResult.CreateTextTooShort(
-                    GetPreviousText(sourceId),
-                    currentText,
-                    GetAppliedThreshold(currentText.Length, regionInfo),
-                    stopwatch.Elapsed);
+                    return TextChangeWithGateResult.CreateTextTooShort(
+                        GetPreviousText(sourceId),
+                        currentText,
+                        GetAppliedThreshold(currentText.Length, regionInfo),
+                        stopwatch.Elapsed);
+                }
             }
 
             // [Issue #465] 静的UI要素チェック（最も早い段階で判定）
@@ -750,6 +765,18 @@ public partial class TextChangeDetectionService : ITextChangeDetectionService
         }
     }
 
+    /// <summary>
+    /// [Issue #491] CJK文字（漢字・ひらがな・カタカナ等）かどうかを判定
+    /// </summary>
+    /// <remarks>
+    /// char.GetUnicodeCategory → OtherLetter でCJK統合漢字、ひらがな、カタカナを広くカバー。
+    /// ラテン文字やアラビア文字等の1文字ノイズとは区別される。
+    /// </remarks>
+    internal static bool IsCjkCharacter(char c)
+    {
+        return char.GetUnicodeCategory(c) == UnicodeCategory.OtherLetter;
+    }
+
     #endregion
 }
 
@@ -779,7 +806,10 @@ internal sealed class DefaultGateStrategy : IGateStrategy
             return GateDecision.EmptyText;
         }
 
-        if (currentText.Length < _settings.MinTextLength)
+        // [Issue #491] CJK1文字はDetectChangeWithGateAsyncで判定済みのため、
+        // ここに到達した場合は許可された1文字テキスト
+        if (currentText.Length < _settings.MinTextLength
+            && !(currentText.Length == 1 && _settings.EnableCjkSingleCharPass && TextChangeDetectionService.IsCjkCharacter(currentText[0])))
         {
             return GateDecision.TextTooShort;
         }


### PR DESCRIPTION
## Summary
- CJK文字(漢字・ひらがな・カタカナ)1文字テキストがOCR信頼度≥0.90の場合、MinTextLength=2のGateチェックを免除してGate通過を許可
- evaluatedZonesの前回値と今回値の差分を追跡し、連続3サイクルOCR不検出のゾーンに対してTextDisappearanceEventを発行してオーバーレイを自動削除
- ゲームのキャラクター名(瞳、蛍、翠等)が正しく翻訳されるようになり、消えたテキストのオーバーレイが残り続ける問題を修正

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `RoiGatekeeperSettings.cs` | `EnableCjkSingleCharPass`/`CjkSingleCharConfidenceThreshold` 設定追加 |
| `TextChangeDetectionService.cs` | MinTextLengthチェックにCJK1文字例外追加、`IsCjkCharacter`ヘルパー |
| `AggregatedChunksReadyEventHandler.cs` | OCR信頼度をGateRegionInfoに設定、OCR不検出カウンター+自動クリア |

## Test plan
- [x] ビルド成功（0エラー、0警告）
- [x] Core 810テスト全通過
- [x] Infrastructure 694テスト全通過
- [x] 実機テスト: `瞳` (Confidence=0.989) がCJK single char Gate passで通過し `Pupil` に翻訳されることを確認
- [x] 実機テスト: OCR不検出カウンターが正常にインクリメント・リセットされることを確認
- [x] Geminiレビュー完了

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)