### PR TITLE
fix(#485): IUIDispatcher抽象化でAvaloniaNavigationServiceTestsのデッドロックを解消

### DIFF
--- a/Baketa.UI/DI/Modules/UIModule.cs
+++ b/Baketa.UI/DI/Modules/UIModule.cs
@@ -146,6 +146,7 @@ internal sealed class UIModule : ServiceModuleBase
         // 例: services.AddSingleton<INotificationService, AvaloniaNotificationService>();
 
         // ページ遷移とナビゲーション
+        services.AddSingleton<IUIDispatcher, AvaloniaUIDispatcher>(); // [Issue #485] Dispatcher抽象化
         services.AddSingleton<INavigationService, AvaloniaNavigationService>();
         // 例: services.AddSingleton<IPageService, AvaloniaPageService>();
 

--- a/Baketa.UI/Services/AvaloniaNavigationService.cs
+++ b/Baketa.UI/Services/AvaloniaNavigationService.cs
@@ -20,12 +20,15 @@ namespace Baketa.UI.Services;
 /// </remarks>
 /// <param name="serviceProvider">サービスプロバイダー</param>
 /// <param name="logger">ロガー</param>
+/// <param name="dispatcher">[Issue #485] UIスレッドディスパッチャー</param>
 internal sealed class AvaloniaNavigationService(
     IServiceProvider serviceProvider,
-    ILogger<AvaloniaNavigationService> logger) : INavigationService, IDisposable
+    ILogger<AvaloniaNavigationService> logger,
+    IUIDispatcher dispatcher) : INavigationService, IDisposable
 {
     private readonly IServiceProvider _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
     private readonly ILogger<AvaloniaNavigationService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly IUIDispatcher _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
     private bool _disposed;
 
     // 🔥 [ISSUE#167] 二重ナビゲーション防止フラグ
@@ -67,7 +70,7 @@ internal sealed class AvaloniaNavigationService(
             {
                 // 🔥 [ISSUE#167] メインウィンドウを表示し、認証モードを有効化
                 // UIスレッドで実行する必要がある
-                await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+                await _dispatcher.InvokeAsync(async () =>
                 {
                     mainOverlayViewModel = _serviceProvider.GetService<MainOverlayViewModel>();
                     if (mainOverlayViewModel != null)
@@ -126,7 +129,7 @@ internal sealed class AvaloniaNavigationService(
             {
                 // 🔥 [ISSUE#167] メインウィンドウを表示し、認証モードを有効化
                 // UIスレッドで実行する必要がある
-                await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+                await _dispatcher.InvokeAsync(async () =>
                 {
                     mainOverlayViewModel = _serviceProvider.GetService<MainOverlayViewModel>();
                     if (mainOverlayViewModel != null)
@@ -179,7 +182,7 @@ internal sealed class AvaloniaNavigationService(
         _isNavigatingToMainWindow = true;
         try
         {
-            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+            await _dispatcher.InvokeAsync(async () =>
             {
                 await ShowMainWindowInternalAsync().ConfigureAwait(false);
             }).ConfigureAwait(false);
@@ -340,7 +343,7 @@ internal sealed class AvaloniaNavigationService(
         {
             _logNavigating(_logger, "SwitchToLogin", null);
 
-            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+            await _dispatcher.InvokeAsync(async () =>
             {
                 if (Avalonia.Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop &&
                     desktop.MainWindow is MainOverlayView mainOverlay)
@@ -370,7 +373,7 @@ internal sealed class AvaloniaNavigationService(
             _logNavigating(_logger, "SwitchToSignup", null);
             _logger.LogDebug("[AUTH_DEBUG] SwitchToSignupAsync開始");
 
-            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
+            await _dispatcher.InvokeAsync(async () =>
             {
                 _logger.LogDebug("[AUTH_DEBUG] UIThread.InvokeAsync内部開始");
 

--- a/Baketa.UI/Services/AvaloniaUIDispatcher.cs
+++ b/Baketa.UI/Services/AvaloniaUIDispatcher.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+
+namespace Baketa.UI.Services;
+
+/// <summary>
+/// Avalonia UIスレッドディスパッチャーの実装
+/// </summary>
+/// <remarks>
+/// [Issue #485] プロダクション環境で使用する実装。
+/// Avalonia の Dispatcher.UIThread を使用してUIスレッドにディスパッチします。
+/// </remarks>
+internal sealed class AvaloniaUIDispatcher : IUIDispatcher
+{
+    /// <inheritdoc/>
+    public async Task InvokeAsync(Func<Task> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        await Dispatcher.UIThread.InvokeAsync(action).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public bool CheckAccess() => Dispatcher.UIThread.CheckAccess();
+}

--- a/Baketa.UI/Services/IUIDispatcher.cs
+++ b/Baketa.UI/Services/IUIDispatcher.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Baketa.UI.Services;
+
+/// <summary>
+/// UIスレッドディスパッチャーの抽象化
+/// </summary>
+/// <remarks>
+/// [Issue #485] Headlessテスト環境での Dispatcher.UIThread.InvokeAsync デッドロックを解消するため、
+/// UIスレッドへのディスパッチを抽象化します。
+/// プロダクション環境では Avalonia の Dispatcher.UIThread を使用し、
+/// テスト環境では同期的に実行するモックを注入できます。
+/// </remarks>
+public interface IUIDispatcher
+{
+    /// <summary>
+    /// UIスレッドで非同期アクションを実行します
+    /// </summary>
+    /// <param name="action">実行するアクション</param>
+    Task InvokeAsync(Func<Task> action);
+
+    /// <summary>
+    /// 現在のスレッドがUIスレッドかどうかを確認します
+    /// </summary>
+    bool CheckAccess();
+}

--- a/tests/Baketa.UI.Tests/Services/AvaloniaNavigationServiceTests.cs
+++ b/tests/Baketa.UI.Tests/Services/AvaloniaNavigationServiceTests.cs
@@ -25,6 +25,7 @@ public sealed class AvaloniaNavigationServiceTests : AvaloniaTestBase
     private readonly Mock<IServiceProvider> _mockServiceProvider;
     private readonly Mock<ILogger<AvaloniaNavigationService>> _mockLogger;
     private readonly Mock<IAuthService> _mockAuthService;
+    private readonly Mock<IUIDispatcher> _mockDispatcher;
     // 削除: 使用しないFieldを削除してテストを簡素化
     private readonly LoginViewModel _loginViewModel;
     private readonly SignupViewModel _signupViewModel;
@@ -37,6 +38,11 @@ public sealed class AvaloniaNavigationServiceTests : AvaloniaTestBase
         _mockServiceProvider = new Mock<IServiceProvider>();
         _mockLogger = new Mock<ILogger<AvaloniaNavigationService>>();
         _mockAuthService = new Mock<IAuthService>();
+        // [Issue #485] UIスレッドディスパッチャーのモック - 同期的に実行してデッドロックを回避
+        _mockDispatcher = new Mock<IUIDispatcher>();
+        _mockDispatcher.Setup(x => x.InvokeAsync(It.IsAny<Func<Task>>()))
+            .Returns<Func<Task>>(action => action());
+        _mockDispatcher.Setup(x => x.CheckAccess()).Returns(true);
         // 削除: 使用しないインスタンス初期化を削除
         // テスト簡素化のためStubLoginViewModel作成
         _loginViewModel = CreateStubLoginViewModel();
@@ -137,7 +143,7 @@ public sealed class AvaloniaNavigationServiceTests : AvaloniaTestBase
     private AvaloniaNavigationService CreateNavigationService()
     {
         _navigationService?.Dispose();
-        _navigationService = new AvaloniaNavigationService(_mockServiceProvider.Object, _mockLogger.Object);
+        _navigationService = new AvaloniaNavigationService(_mockServiceProvider.Object, _mockLogger.Object, _mockDispatcher.Object);
         return _navigationService;
     }
 
@@ -176,7 +182,7 @@ public sealed class AvaloniaNavigationServiceTests : AvaloniaTestBase
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            new AvaloniaNavigationService(null!, _mockLogger.Object));
+            new AvaloniaNavigationService(null!, _mockLogger.Object, _mockDispatcher.Object));
     }
 
     [Fact]
@@ -184,7 +190,15 @@ public sealed class AvaloniaNavigationServiceTests : AvaloniaTestBase
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            new AvaloniaNavigationService(_mockServiceProvider.Object, null!));
+            new AvaloniaNavigationService(_mockServiceProvider.Object, null!, _mockDispatcher.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithNullDispatcher_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new AvaloniaNavigationService(_mockServiceProvider.Object, _mockLogger.Object, null!));
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Headlessテスト環境で `Dispatcher.UIThread.InvokeAsync` がメッセージループ未起動のためデッドロックしていた16/25テストを解消
- `IUIDispatcher` インターフェースを導入し、Dispatcher呼び出しを抽象化。テスト環境では同期実行Mockを注入
- プロダクション動作への影響なし（`AvaloniaUIDispatcher` が実 `Dispatcher.UIThread` をラップ）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `Baketa.UI/Services/IUIDispatcher.cs` | **新規** — UIスレッドディスパッチャーインターフェース |
| `Baketa.UI/Services/AvaloniaUIDispatcher.cs` | **新規** — プロダクション用実装 |
| `Baketa.UI/Services/AvaloniaNavigationService.cs` | **修正** — DI注入、5箇所のInvokeAsync置換 |
| `Baketa.UI/DI/Modules/UIModule.cs` | **修正** — DI登録追加 |
| `tests/.../AvaloniaNavigationServiceTests.cs` | **修正** — Mock注入、テスト追加 |

## Test plan
- [x] AvaloniaNavigationServiceTests: 26/26 成功（デッドロック解消 + 新規1テスト）
- [x] Baketa.Core.Tests: 810 成功
- [x] Baketa.Infrastructure.Tests: 694 成功
- [x] Baketa.UI.Tests: 451 成功
- [x] 回帰なし

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)