### PR TITLE
feat(#495): 初回セットアップウィザード（母国語選択→言語ペア自動設定）

### DIFF
--- a/Baketa.UI/App.axaml.cs
+++ b/Baketa.UI/App.axaml.cs
@@ -21,6 +21,7 @@ using Baketa.Core.Settings;
 using Baketa.Infrastructure.Platform.Windows.Capture;
 using Baketa.Infrastructure.Services;
 using Baketa.UI.Resources;
+using Baketa.UI.Configuration;
 using Baketa.UI.Services;
 using Baketa.UI.Utils;
 using Baketa.UI.ViewModels;
@@ -391,6 +392,9 @@ internal sealed partial class App : Avalonia.Application, IDisposable
                     {
                         // 🔥 [ISSUE#167] デバッグ出力
                         Console.WriteLine("🔥🔥🔥 [AUTH_DEBUG] InvokeAsync開始 🔥🔥🔥");
+
+                        // --- 0. [Issue #495] 初回セットアップウィザード（ローディング前に表示） ---
+                        await CheckAndShowFirstRunWizardAsync(serviceProvider);
 
                         // --- 1. ローディング画面の準備 ---
                         _logger?.LogInformation("ローディング画面初期化開始");
@@ -1100,6 +1104,61 @@ internal sealed partial class App : Avalonia.Application, IDisposable
         {
             // クラッシュレポート処理の失敗はアプリ起動をブロックしない
             _logger?.LogWarning(ex, "[Issue #252] クラッシュレポート処理中にエラー（継続）");
+        }
+    }
+
+    /// <summary>
+    /// [Issue #495] 初回セットアップウィザード表示
+    /// 初回起動時に母国語を選択させ、TargetLang + UI言語を自動設定
+    /// ConsentDialogの前に表示することで、同意画面も選択言語で表示される
+    /// </summary>
+    private async Task CheckAndShowFirstRunWizardAsync(IServiceProvider serviceProvider)
+    {
+        try
+        {
+            var firstRunService = serviceProvider.GetService<Infrastructure.Services.IFirstRunService>();
+            if (firstRunService == null || !firstRunService.IsFirstRun())
+            {
+                _logger?.LogDebug("[Issue #495] 初回起動ではないため、ウィザードをスキップ");
+                return;
+            }
+
+            _logger?.LogInformation("[Issue #495] 初回起動を検出 - セットアップウィザードを表示");
+
+            var localizationService = serviceProvider.GetRequiredService<ILocalizationService>();
+            var settingsFileManager = serviceProvider.GetRequiredService<SettingsFileManager>();
+            var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+
+            var viewModel = new FirstRunWizardViewModel(
+                localizationService,
+                settingsFileManager,
+                firstRunService,
+                loggerFactory.CreateLogger<FirstRunWizardViewModel>());
+
+            var wizard = new FirstRunWizardWindow(viewModel);
+
+            // アイコン設定
+            try
+            {
+                var iconUri = new Uri(BAKETA_ICON_PATH);
+                wizard.Icon = new Avalonia.Controls.WindowIcon(Avalonia.Platform.AssetLoader.Open(iconUri));
+            }
+            catch (Exception iconEx)
+            {
+                Console.WriteLine($"[Issue #495] ウィザードアイコン設定失敗: {iconEx.Message}");
+            }
+
+            // ダイアログとして表示し、完了を待つ
+            wizard.Show();
+            var tcs = new TaskCompletionSource<bool>();
+            wizard.Closed += (_, _) => tcs.TrySetResult(viewModel.IsCompleted);
+            await tcs.Task.ConfigureAwait(true);
+
+            _logger?.LogInformation("[Issue #495] セットアップウィザード完了: IsCompleted={IsCompleted}", viewModel.IsCompleted);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "[Issue #495] セットアップウィザード処理中にエラー（継続）");
         }
     }
 

--- a/Baketa.UI/ViewModels/FirstRunWizardViewModel.cs
+++ b/Baketa.UI/ViewModels/FirstRunWizardViewModel.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Baketa.UI.Configuration;
+using Baketa.UI.Models;
+using Baketa.UI.Services;
+using Microsoft.Extensions.Logging;
+using ReactiveUI;
+
+namespace Baketa.UI.ViewModels;
+
+/// <summary>
+/// [Issue #495] 初回セットアップウィザード ViewModel
+/// 母国語を選択するだけで TargetLang + UI言語が自動設定される
+/// </summary>
+public sealed class FirstRunWizardViewModel : ReactiveObject
+{
+    private readonly ILocalizationService _localizationService;
+    private readonly SettingsFileManager _settingsFileManager;
+    private readonly Infrastructure.Services.IFirstRunService _firstRunService;
+    private readonly ILogger<FirstRunWizardViewModel> _logger;
+
+    /// <summary>
+    /// 現在選択可能な言語コード（言語拡張時にここに追加するだけでOK）
+    /// </summary>
+    private static readonly HashSet<string> EnabledLanguageCodes = ["en", "ja"];
+
+    private SupportedLanguage? _selectedLanguage;
+
+    /// <summary>
+    /// 選択可能な言語一覧（EnabledLanguageCodesでフィルタ）
+    /// </summary>
+    public IReadOnlyList<SupportedLanguage> AvailableLanguages { get; }
+
+    /// <summary>
+    /// 選択された母国語
+    /// </summary>
+    public SupportedLanguage? SelectedLanguage
+    {
+        get => _selectedLanguage;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedLanguage, value);
+            if (value != null)
+            {
+                _ = OnLanguageSelectedAsync(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// ウィザード完了（確定ボタン）コマンド
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> ConfirmCommand { get; }
+
+    /// <summary>
+    /// ウィザードが完了したか
+    /// </summary>
+    public bool IsCompleted { get; private set; }
+
+    public FirstRunWizardViewModel(
+        ILocalizationService localizationService,
+        SettingsFileManager settingsFileManager,
+        Infrastructure.Services.IFirstRunService firstRunService,
+        ILogger<FirstRunWizardViewModel> logger)
+    {
+        _localizationService = localizationService ?? throw new ArgumentNullException(nameof(localizationService));
+        _settingsFileManager = settingsFileManager ?? throw new ArgumentNullException(nameof(settingsFileManager));
+        _firstRunService = firstRunService ?? throw new ArgumentNullException(nameof(firstRunService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // EnabledLanguageCodesでフィルタした言語リスト
+        AvailableLanguages = _localizationService.SupportedLanguages
+            .Where(lang => EnabledLanguageCodes.Contains(lang.Code))
+            .ToList()
+            .AsReadOnly();
+
+        // デフォルト: English
+        _selectedLanguage = AvailableLanguages.FirstOrDefault(l => l.Code == "en")
+            ?? AvailableLanguages.FirstOrDefault();
+
+        var canConfirm = this.WhenAnyValue(x => x.SelectedLanguage)
+            .Select(lang => lang != null);
+        ConfirmCommand = ReactiveCommand.CreateFromTask(ConfirmAsync, canConfirm);
+    }
+
+    /// <summary>
+    /// 言語選択時にUI言語をリアルタイム切替
+    /// </summary>
+    private async Task OnLanguageSelectedAsync(SupportedLanguage language)
+    {
+        try
+        {
+            _logger.LogInformation("[Issue #495] 言語選択: {Code} ({Name})", language.Code, language.NativeName);
+            await _localizationService.ChangeLanguageAsync(language.Code).ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Issue #495] UI言語切替に失敗: {Code}", language.Code);
+        }
+    }
+
+    /// <summary>
+    /// ウィザード確定: TargetLang保存 + UI言語保存 + MarkAsRun
+    /// </summary>
+    private async Task ConfirmAsync()
+    {
+        if (SelectedLanguage == null) return;
+
+        try
+        {
+            var targetLang = SelectedLanguage.Code;
+            var sourceLang = DetermineSourceLanguage(targetLang);
+
+            // UI言語を確実に適用（デフォルト選択のままOKした場合、setterを経由しないため）
+            await _localizationService.ChangeLanguageAsync(targetLang).ConfigureAwait(true);
+
+            var languagePair = $"{sourceLang}-{targetLang}";
+            await _settingsFileManager.SaveLanguagePairSettingsAsync(
+                languagePair, ChineseVariant.Auto).ConfigureAwait(true);
+
+            _logger.LogInformation("[Issue #495] ウィザード完了 - LanguagePair: {Pair}, UiLanguage: {UiLang}",
+                languagePair, targetLang);
+
+            // 初回起動フラグをマーク
+            _firstRunService.MarkAsRun();
+
+            IsCompleted = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Issue #495] ウィザード確定処理に失敗");
+        }
+    }
+
+    /// <summary>
+    /// 母国語（TargetLang）からソース言語を決定する。
+    /// - デフォルト: "en"（大半のゲームは英語）
+    /// - TargetLangが"en"の場合: "ja"（Baketaの主要対象は日本語ゲーム）
+    ///   言語拡張後はユーザーが設定画面で変更可能
+    /// </summary>
+    private static string DetermineSourceLanguage(string targetLang)
+    {
+        const string defaultSource = "en";
+        const string fallbackForEnglishUsers = "ja";
+
+        return targetLang != defaultSource ? defaultSource : fallbackForEnglishUsers;
+    }
+}

--- a/Baketa.UI/ViewModels/MainOverlayViewModel.cs
+++ b/Baketa.UI/ViewModels/MainOverlayViewModel.cs
@@ -2088,38 +2088,21 @@ public class MainOverlayViewModel : ViewModelBase
     #region FirstRun
 
     /// <summary>
-    /// 初回起動チェックと設定画面自動表示
+    /// 初回起動チェック
+    /// [Issue #495] ウィザードはApp.axaml.csで処理済みのため、ここでは追加処理のみ
     /// </summary>
-    private async Task CheckAndHandleFirstRunAsync()
+    private Task CheckAndHandleFirstRunAsync()
     {
-        try
+        if (_firstRunService.IsFirstRun())
         {
-            Logger?.LogInformation("🔍 初回起動チェック開始");
-
-            if (_firstRunService.IsFirstRun())
-            {
-                Logger?.LogInformation("✅ 初回起動を検出 - 設定画面を自動表示します");
-
-                // UIスレッドで設定画面を開く
-                await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
-                {
-                    Logger?.LogInformation("🎯 設定画面を開きます");
-                    ExecuteSettings();
-                });
-
-                // 初回起動フラグをマーク
-                _firstRunService.MarkAsRun();
-                Logger?.LogInformation("✅ 初回起動フラグをマークしました");
-            }
-            else
-            {
-                Logger?.LogInformation("ℹ️ 2回目以降の起動です");
-            }
+            Logger?.LogDebug("[Issue #495] 初回起動（ウィザード未完了の可能性）");
         }
-        catch (Exception ex)
+        else
         {
-            Logger?.LogError(ex, "❌ 初回起動チェック処理でエラーが発生しました: {Message}", ex.Message);
+            Logger?.LogDebug("2回目以降の起動です");
         }
+
+        return Task.CompletedTask;
     }
 
     #endregion

--- a/Baketa.UI/Views/FirstRunWizardWindow.axaml
+++ b/Baketa.UI/Views/FirstRunWizardWindow.axaml
@@ -1,0 +1,67 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Baketa.UI.ViewModels"
+        x:Class="Baketa.UI.Views.FirstRunWizardWindow"
+        Title="Baketa - Setup"
+        Width="460"
+        MinHeight="380"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterScreen"
+        CanResize="False"
+        ShowInTaskbar="True"
+        Topmost="True"
+        x:DataType="vm:FirstRunWizardViewModel">
+
+    <Window.Styles>
+        <Style Selector="Button.primary">
+            <Setter Property="Background" Value="{DynamicResource SystemAccentColor}"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="Padding" Value="24,10"/>
+            <Setter Property="MinWidth" Value="160"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="FontSize" Value="14"/>
+        </Style>
+    </Window.Styles>
+
+    <StackPanel Margin="32" Spacing="24">
+        <!-- Logo + App Name -->
+        <StackPanel HorizontalAlignment="Center" Spacing="8">
+            <Image Source="avares://Baketa/Assets/Icons/baketa-256.png"
+                   Width="72" Height="72"
+                   HorizontalAlignment="Center"/>
+            <TextBlock Text="Baketa"
+                       FontSize="26"
+                       FontWeight="SemiBold"
+                       HorizontalAlignment="Center"/>
+        </StackPanel>
+
+        <!-- Description -->
+        <TextBlock Text="Select your language / あなたの言語を選択してください"
+                   TextWrapping="Wrap"
+                   TextAlignment="Center"
+                   FontSize="14"
+                   Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                   HorizontalAlignment="Center"
+                   MaxWidth="380"/>
+
+        <!-- Language Selection -->
+        <ComboBox ItemsSource="{Binding AvailableLanguages}"
+                  SelectedItem="{Binding SelectedLanguage}"
+                  HorizontalAlignment="Stretch"
+                  MinHeight="40"
+                  FontSize="14">
+            <ComboBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding NativeName}" FontWeight="SemiBold"/>
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+
+        <!-- Confirm Button -->
+        <Button Classes="primary"
+                Content="OK"
+                Command="{Binding ConfirmCommand}"
+                HorizontalAlignment="Center"
+                Name="ConfirmButton"/>
+    </StackPanel>
+</Window>

--- a/Baketa.UI/Views/FirstRunWizardWindow.axaml.cs
+++ b/Baketa.UI/Views/FirstRunWizardWindow.axaml.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Reactive.Linq;
+using Avalonia.Controls;
+using Baketa.UI.ViewModels;
+
+namespace Baketa.UI.Views;
+
+/// <summary>
+/// [Issue #495] 初回セットアップウィザードウィンドウ
+/// </summary>
+public partial class FirstRunWizardWindow : Window
+{
+    /// <summary>
+    /// デザイナー用コンストラクタ
+    /// </summary>
+    public FirstRunWizardWindow()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// ViewModelを指定してウィンドウを作成
+    /// </summary>
+    public FirstRunWizardWindow(FirstRunWizardViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+
+        // ConfirmCommand完了後にウィンドウを閉じる（Command bindingと競合しない）
+        viewModel.ConfirmCommand
+            .Where(_ => viewModel.IsCompleted)
+            .Take(1)
+            .Subscribe(_ => Close(true));
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+    }
+}

--- a/grpc_server/BaketaUnifiedServer.spec
+++ b/grpc_server/BaketaUnifiedServer.spec
@@ -31,6 +31,11 @@ a = Analysis(
         'grpc',
         'grpc._cython',
         'grpc._cython.cygrpc',
+        'grpc_health',
+        'grpc_health.v1',
+        'grpc_health.v1.health',
+        'grpc_health.v1.health_pb2',
+        'grpc_health.v1.health_pb2_grpc',
         'google.protobuf',
         'google.protobuf.timestamp_pb2',
 


### PR DESCRIPTION
## Summary

- 初回起動時に母国語を選択するだけで TargetLang + UI言語が自動設定されるセットアップウィザードを実装
- 起動フロー: ウィザード → ConsentDialog → メイン画面（ウィザードで言語を先に確定するため、ConsentDialogが最初から選択言語で表示される）
- 現時点では英語/日本語の2言語のみ（Issue #475 の多言語対応で拡張予定）

## Changes

### 新規ファイル
| ファイル | 内容 |
|---------|------|
| `FirstRunWizardViewModel.cs` | 言語選択ViewModel（リアルタイムUI言語切替、言語ペア自動設定、`DetermineSourceLanguage`） |
| `FirstRunWizardWindow.axaml` | ウィザードUI（ロゴ + 説明 + 言語ComboBox + OKボタン） |
| `FirstRunWizardWindow.axaml.cs` | コードビハインド（`ConfirmCommand.Subscribe`でウィンドウクローズ） |

### 変更ファイル
| ファイル | 内容 |
|---------|------|
| `App.axaml.cs` | Step 0にウィザード表示を追加（ConsentDialogより前） |
| `MainOverlayViewModel.cs` | 初回起動チェックを簡素化（ウィザードはApp.axaml.csに移動） |
| `BaketaUnifiedServer.spec` | `grpc_health`モジュールをhiddenimportsに追加 |

### 修正したバグ
1. **en-en言語ペア問題**: `DetermineSourceLanguage()` で母国語が英語の場合は `ja` をソース言語に設定
2. **デフォルト選択時のUI言語未切替**: `ConfirmAsync`内で`ChangeLanguageAsync`を明示的に呼び出し
3. **ConfirmAsync二重実行**: XAML Command binding + Click handler の競合を`ConfirmCommand.Subscribe`で解消
4. **grpc_health ModuleNotFoundError**: PyInstaller hiddenimportsに追加

## Test plan

- [x] 日本語選択 → UI日本語切替、言語ペア `en-ja` 保存を確認
- [x] 英語選択 → UI英語切替、言語ペア `ja-en` 保存を確認
- [x] デフォルト選択（English）のままOK → UI言語が確実に適用されることを確認
- [x] 2回目以降の起動ではウィザードが表示されないことを確認
- [ ] ビルド成功確認

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)