### PR TITLE
fix(#477): OGP画像URLパス修正

### DIFF
--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -17,14 +17,14 @@
   <meta name="keywords" content="game translation, OCR overlay, real-time translation, gaming, Windows app, free, open source, Baketa, ゲーム翻訳, 遊戲翻譯, 게임 번역">
   <meta name="author" content="Baketa">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://koizumiiiii.github.io/Baketa/">
+  <link rel="canonical" href="https://koizumiiiii.github.io/Baketa/pages/">
 
   <!-- Open Graph (Facebook, Discord, etc.) -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Baketa - Game Translation Overlay">
   <meta property="og:description" content="Free, open-source real-time game translation. OCR detects text on screen and overlays translations. 10 languages supported.">
-  <meta property="og:url" content="https://koizumiiiii.github.io/Baketa/">
-  <meta property="og:image" content="https://koizumiiiii.github.io/Baketa/assets/icons/baketa-256.png">
+  <meta property="og:url" content="https://koizumiiiii.github.io/Baketa/pages/">
+  <meta property="og:image" content="https://koizumiiiii.github.io/Baketa/pages/assets/icons/baketa-256.png">
   <meta property="og:image:width" content="256">
   <meta property="og:image:height" content="256">
   <meta property="og:site_name" content="Baketa">
@@ -38,7 +38,7 @@
   <meta name="twitter:site" content="@Baketa_app">
   <meta name="twitter:title" content="Baketa - Game Translation Overlay">
   <meta name="twitter:description" content="Free, open-source real-time game translation. OCR detects text on screen and overlays translations.">
-  <meta name="twitter:image" content="https://koizumiiiii.github.io/Baketa/assets/icons/baketa-256.png">
+  <meta name="twitter:image" content="https://koizumiiiii.github.io/Baketa/pages/assets/icons/baketa-256.png">
 
   <!-- Structured Data (JSON-LD) for Google / LLM -->
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- OGP/Twitter Card画像URLに`/pages/`パスが欠落していた問題を修正
- canonical URLも同様に修正

## Test plan
- [ ] https://koizumiiiii.github.io/Baketa/pages/assets/icons/baketa-256.png が200を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)