### PR TITLE
feat(#521): FallbackOrchestratorクールダウン時間のエラータイプ別分離

### DIFF
--- a/Baketa.Infrastructure/Translation/Services/FallbackOrchestrator.cs
+++ b/Baketa.Infrastructure/Translation/Services/FallbackOrchestrator.cs
@@ -27,9 +27,14 @@ public sealed class FallbackOrchestrator : IFallbackOrchestrator
     private const string SecondaryKey = "secondary";
 
     /// <summary>
-    /// フォールバック無効化期間（エンジン失敗後）
+    /// [Issue #521] ヘルスチェック失敗時のクールダウン（一時的なネットワーク問題）
     /// </summary>
-    private static readonly TimeSpan FallbackCooldown = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan HealthCheckCooldown = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// [Issue #521] APIエラー・ハルシネーション・予期せぬ例外時のクールダウン
+    /// </summary>
+    private static readonly TimeSpan ApiErrorCooldown = TimeSpan.FromMinutes(5);
 
     /// <summary>
     /// コンストラクタ
@@ -190,9 +195,10 @@ public sealed class FallbackOrchestrator : IFallbackOrchestrator
                     Duration = DateTime.UtcNow - startTime
                 });
 
+                // [Issue #521] ヘルスチェック失敗は一時的 → 短いクールダウン
                 _engineStatusManager.MarkEngineUnavailable(
                     engineKey,
-                    FallbackCooldown,
+                    HealthCheckCooldown,
                     "可用性チェック失敗");
 
                 return null;
@@ -223,7 +229,7 @@ public sealed class FallbackOrchestrator : IFallbackOrchestrator
 
                     _engineStatusManager.MarkEngineUnavailable(
                         engineKey,
-                        FallbackCooldown,
+                        ApiErrorCooldown,
                         $"Hallucination: {hallucinationReason}");
 
                     return null; // → 次のエンジンへフォールバック
@@ -307,7 +313,7 @@ public sealed class FallbackOrchestrator : IFallbackOrchestrator
             {
                 _engineStatusManager.MarkEngineUnavailable(
                     engineKey,
-                    FallbackCooldown,
+                    ApiErrorCooldown,
                     response.Error.Message);
             }
 
@@ -333,7 +339,7 @@ public sealed class FallbackOrchestrator : IFallbackOrchestrator
 
             _engineStatusManager.MarkEngineUnavailable(
                 engineKey,
-                FallbackCooldown,
+                ApiErrorCooldown,
                 ex.Message);
 
             return null;

--- a/tests/Baketa.Application.Tests/Services/Translation/TranslationOrchestrationServiceTests.cs
+++ b/tests/Baketa.Application.Tests/Services/Translation/TranslationOrchestrationServiceTests.cs
@@ -426,8 +426,8 @@ public class TranslationOrchestrationServiceTests : IDisposable
         // Act
         await _service.StartAutomaticTranslationAsync(null, CancellationToken.None);
 
-        // エラー発生後も処理が継続されるまで少し待機
-        await Task.Delay(300);
+        // エラー発生後も処理が継続されるまで待機（CI環境では処理が遅いため余裕を持たせる）
+        await Task.Delay(3000);
 
         // Assert
         _service.IsAutomaticTranslationActive.Should().BeTrue();

--- a/tests/Baketa.Infrastructure.Tests/Translation/FallbackOrchestratorTests.cs
+++ b/tests/Baketa.Infrastructure.Tests/Translation/FallbackOrchestratorTests.cs
@@ -287,9 +287,44 @@ public class FallbackOrchestratorTests
         Assert.True(result.IsSuccess);
         Assert.Equal(FallbackLevel.Secondary, result.UsedEngine);
 
-        // Verify engine was marked unavailable
+        // Verify engine was marked unavailable with ApiErrorCooldown (5 min)
         _mockEngineStatusManager.Verify(
-            x => x.MarkEngineUnavailable(PrimaryKey, It.IsAny<TimeSpan>(), It.IsAny<string>()),
+            x => x.MarkEngineUnavailable(PrimaryKey, TimeSpan.FromMinutes(5), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// [Issue #521] ヘルスチェック失敗時は短いクールダウン（30秒）が適用されることを検証
+    /// </summary>
+    [Fact]
+    public async Task TranslateWithFallbackAsync_HealthCheckFails_UsesShortCooldown()
+    {
+        // Arrange
+        var request = CreateTestRequest();
+
+        var mockPrimaryTranslator = new Mock<ICloudImageTranslator>();
+        mockPrimaryTranslator.Setup(x => x.ProviderId).Returns("primary");
+        mockPrimaryTranslator
+            .Setup(x => x.IsAvailableAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false); // ヘルスチェック失敗
+
+        var mockSecondaryTranslator = CreateMockTranslator("secondary", true, request.RequestId);
+
+        SetupEngineAvailable(PrimaryKey, true);
+        SetupEngineAvailable(SecondaryKey, true);
+        SetupKeyedService(PrimaryKey, mockPrimaryTranslator.Object);
+        SetupKeyedService(SecondaryKey, mockSecondaryTranslator.Object);
+
+        // Act
+        var result = await _orchestrator.TranslateWithFallbackAsync(request);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(FallbackLevel.Secondary, result.UsedEngine);
+
+        // [Issue #521] ヘルスチェック失敗は30秒クールダウン
+        _mockEngineStatusManager.Verify(
+            x => x.MarkEngineUnavailable(PrimaryKey, TimeSpan.FromSeconds(30), "可用性チェック失敗"),
             Times.Once);
     }
 


### PR DESCRIPTION
## Summary
- ヘルスチェック失敗（一時的なネットワーク問題）のクールダウンを5分→30秒に短縮
- APIエラー・ハルシネーション・予期せぬ例外は5分のまま据え置き
- `FallbackCooldown` → `HealthCheckCooldown`(30s) + `ApiErrorCooldown`(5min) に分離

## 変更箇所
| エラータイプ | 変更前 | 変更後 |
|-------------|--------|--------|
| 可用性チェック失敗 | 5分 | **30秒** |
| ハルシネーション検出 | 5分 | 5分（据え置き） |
| リトライ不可APIエラー | 5分 | 5分（据え置き） |
| 予期せぬ例外 | 5分 | 5分（据え置き） |

## Test plan
- [x] ビルド成功（0エラー、0警告）
- [x] FallbackOrchestrator全17テスト成功
- [x] ヘルスチェック失敗時の30秒クールダウン検証テスト追加
- [x] Geminiレビュー完了

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)