### PR TITLE
feat(#527, #528): 翻訳言語ComboBoxのi18n対応とStartButtonTooltip言語切替修正

### DIFF
--- a/Baketa.UI/Converters/CommonConverters.cs
+++ b/Baketa.UI/Converters/CommonConverters.cs
@@ -377,6 +377,24 @@ internal sealed class BoolToChangesConverter : IValueConverter
 }
 
 /// <summary>
+/// [Issue #527] 言語コードからローカライズされた表示名への変換コンバーター
+/// </summary>
+internal sealed class LanguageCodeToDisplayNameConverter : IValueConverter
+{
+    public static readonly LanguageCodeToDisplayNameConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is string code)
+            return Models.AvailableLanguages.GetLocalizedDisplayName(code);
+        return value;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => BindingOperations.DoNothing;
+}
+
+/// <summary>
 /// [Issue #307] パーセンテージ（double）からGridLength（Star単位）への変換コンバーター
 /// トークンゲージの3セグメント表示に使用
 /// </summary>

--- a/Baketa.UI/Models/TranslationModels.cs
+++ b/Baketa.UI/Models/TranslationModels.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Baketa.UI.Resources;
 using ReactiveUI;
 
 namespace Baketa.UI.Models;
@@ -246,6 +247,25 @@ public static class AvailableLanguages
         new() { Code = "es", DisplayName = "スペイン語", NativeName = "Español", Flag = "🇪🇸", RegionCode = "ES" },
         new() { Code = "pt", DisplayName = "ポルトガル語", NativeName = "Português", Flag = "🇧🇷", RegionCode = "BR" }
     ];
+
+    /// <summary>
+    /// 言語コードからローカライズされた表示名を取得
+    /// </summary>
+    public static string GetLocalizedDisplayName(string code) => code switch
+    {
+        "auto" => Strings.Lang_Auto,
+        "ja" => Strings.Lang_Japanese,
+        "en" => Strings.Lang_English,
+        "zh-CN" => Strings.Lang_ChineseSimplified,
+        "zh-TW" => Strings.Lang_ChineseTraditional,
+        "ko" => Strings.Lang_Korean,
+        "fr" => Strings.Lang_French,
+        "de" => Strings.Lang_German,
+        "it" => Strings.Lang_Italian,
+        "es" => Strings.Lang_Spanish,
+        "pt" => Strings.Lang_Portuguese,
+        _ => code
+    };
 
     /// <summary>
     /// 現在サポートされている言語ペア（全言語間の組み合わせを動的生成）

--- a/Baketa.UI/Resources/Strings.Designer.cs
+++ b/Baketa.UI/Resources/Strings.Designer.cs
@@ -700,4 +700,22 @@ public static class Strings
     public static string Upsell_Free_WithBonus_Message => GetString("Upsell_Free_WithBonus_Message");
     public static string Upsell_Free_NoBonus_Message => GetString("Upsell_Free_NoBonus_Message");
     public static string Upsell_Upgrade_Message => GetString("Upsell_Upgrade_Message");
+
+    // Issue #527: Language Display Names
+    public static string Lang_Auto => GetString("Lang_Auto");
+    public static string Lang_Japanese => GetString("Lang_Japanese");
+    public static string Lang_English => GetString("Lang_English");
+    public static string Lang_ChineseSimplified => GetString("Lang_ChineseSimplified");
+    public static string Lang_ChineseTraditional => GetString("Lang_ChineseTraditional");
+    public static string Lang_Korean => GetString("Lang_Korean");
+    public static string Lang_French => GetString("Lang_French");
+    public static string Lang_German => GetString("Lang_German");
+    public static string Lang_Italian => GetString("Lang_Italian");
+    public static string Lang_Spanish => GetString("Lang_Spanish");
+    public static string Lang_Portuguese => GetString("Lang_Portuguese");
+    public static string Lang_ChineseVariant_Simplified => GetString("Lang_ChineseVariant_Simplified");
+    public static string Lang_ChineseVariant_Traditional => GetString("Lang_ChineseVariant_Traditional");
+    public static string Lang_ChineseVariant_Auto => GetString("Lang_ChineseVariant_Auto");
+    public static string Lang_ChineseVariant_Cantonese => GetString("Lang_ChineseVariant_Cantonese");
+    public static string Lang_TranslationStrategy_TwoStage => GetString("Lang_TranslationStrategy_TwoStage");
 }

--- a/Baketa.UI/Resources/Strings.de.resx
+++ b/Baketa.UI/Resources/Strings.de.resx
@@ -1748,4 +1748,54 @@ Maßnahme: Bitte starten Sie die App neu.</value>
     <value>⬆️ Upgraden Sie Ihren Plan für mehr Token</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>Automatische Erkennung</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>Japanisch</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>Englisch</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>Chinesisch (Vereinfacht)</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>Chinesisch (Traditionell)</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>Koreanisch</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>Französisch</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>Deutsch</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>Italienisch</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>Spanisch</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>Portugiesisch</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>Vereinfacht</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>Traditionell</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>Automatisch</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>Kantonesisch</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>(Zweistufige Übersetzung)</value>
+  </data>
+
 </root>

--- a/Baketa.UI/Resources/Strings.es.resx
+++ b/Baketa.UI/Resources/Strings.es.resx
@@ -1748,4 +1748,54 @@ Acción: Reinicie la aplicación.</value>
     <value>⬆️ Actualice su plan para más tokens</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>Detección automática</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>Japonés</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>Inglés</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>Chino (Simplificado)</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>Chino (Tradicional)</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>Coreano</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>Francés</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>Alemán</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>Italiano</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>Español</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>Portugués</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>Simplificado</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>Tradicional</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>Automático</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>Cantonés</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>(Traducción en dos etapas)</value>
+  </data>
+
 </root>

--- a/Baketa.UI/Resources/Strings.fr.resx
+++ b/Baketa.UI/Resources/Strings.fr.resx
@@ -1748,4 +1748,54 @@ Action : Veuillez redémarrer l'application.</value>
     <value>⬆️ Passez à un forfait supérieur pour plus de jetons</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>Détection automatique</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>Japonais</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>Anglais</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>Chinois (Simplifié)</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>Chinois (Traditionnel)</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>Coréen</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>Français</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>Allemand</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>Italien</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>Espagnol</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>Portugais</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>Simplifié</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>Traditionnel</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>Automatique</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>Cantonais</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>(Traduction en deux étapes)</value>
+  </data>
+
 </root>

--- a/Baketa.UI/Resources/Strings.it.resx
+++ b/Baketa.UI/Resources/Strings.it.resx
@@ -1748,4 +1748,54 @@ Azione: Riavvii l'app.</value>
     <value>⬆️ Effettui l'upgrade del Suo piano per più token</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>Rilevamento automatico</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>Giapponese</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>Inglese</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>Cinese (Semplificato)</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>Cinese (Tradizionale)</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>Coreano</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>Francese</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>Tedesco</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>Italiano</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>Spagnolo</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>Portoghese</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>Semplificato</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>Tradizionale</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>Automatico</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>Cantonese</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>(Traduzione in due fasi)</value>
+  </data>
+
 </root>

--- a/Baketa.UI/Resources/Strings.ja.resx
+++ b/Baketa.UI/Resources/Strings.ja.resx
@@ -1748,4 +1748,54 @@
     <value>⬆️ プランアップグレードでもっと使える</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>自動検出</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>日本語</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>英語</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>簡体字中国語</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>繁体字中国語</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>韓国語</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>フランス語</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>ドイツ語</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>イタリア語</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>スペイン語</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>ポルトガル語</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>簡体字</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>繁体字</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>自動</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>広東語</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>（2段階翻訳）</value>
+  </data>
+
 </root>

--- a/Baketa.UI/Resources/Strings.ko.resx
+++ b/Baketa.UI/Resources/Strings.ko.resx
@@ -1748,4 +1748,54 @@
     <value>⬆️ 플랜을 업그레이드하여 더 많은 토큰을 받으세요</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>자동 감지</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>일본어</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>영어</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>중국어 (간체)</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>중국어 (번체)</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>한국어</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>프랑스어</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>독일어</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>이탈리아어</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>스페인어</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>포르투갈어</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>간체</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>번체</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>자동</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>광동어</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>(2단계 번역)</value>
+  </data>
+
 </root>

--- a/Baketa.UI/Resources/Strings.pt.resx
+++ b/Baketa.UI/Resources/Strings.pt.resx
@@ -1748,4 +1748,54 @@ Ação: Reinicie o aplicativo.</value>
     <value>⬆️ Atualize seu plano para mais tokens</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>Detecção automática</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>Japonês</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>Inglês</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>Chinês (Simplificado)</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>Chinês (Tradicional)</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>Coreano</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>Francês</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>Alemão</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>Italiano</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>Espanhol</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>Português</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>Simplificado</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>Tradicional</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>Automático</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>Cantonês</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>(Tradução em duas etapas)</value>
+  </data>
+
 </root>

--- a/Baketa.UI/Resources/Strings.resx
+++ b/Baketa.UI/Resources/Strings.resx
@@ -1748,4 +1748,54 @@ Action: Please restart the app.</value>
     <value>⬆️ Upgrade your plan for more tokens</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>Auto Detect</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>Japanese</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>Chinese (Simplified)</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>Chinese (Traditional)</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>Korean</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>French</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>German</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>Italian</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>Spanish</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>Portuguese</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>Simplified</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>Traditional</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>Auto</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>Cantonese</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>(Two-stage translation)</value>
+  </data>
+
 </root>

--- a/Baketa.UI/Resources/Strings.zh-CN.resx
+++ b/Baketa.UI/Resources/Strings.zh-CN.resx
@@ -1748,4 +1748,54 @@
     <value>⬆️ 升级方案获取更多额度</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>自动检测</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>日语</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>英语</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>简体中文</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>繁体中文</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>韩语</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>法语</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>德语</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>意大利语</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>西班牙语</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>葡萄牙语</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>简体</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>繁体</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>自动</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>粤语</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>（两阶段翻译）</value>
+  </data>
+
 </root>

--- a/Baketa.UI/Resources/Strings.zh-TW.resx
+++ b/Baketa.UI/Resources/Strings.zh-TW.resx
@@ -1748,4 +1748,54 @@
     <value>⬆️ 升級方案取得更多額度</value>
   </data>
 
+  <!-- ========== Issue #527: Language Display Names ========== -->
+  <data name="Lang_Auto" xml:space="preserve">
+    <value>自動偵測</value>
+  </data>
+  <data name="Lang_Japanese" xml:space="preserve">
+    <value>日語</value>
+  </data>
+  <data name="Lang_English" xml:space="preserve">
+    <value>英語</value>
+  </data>
+  <data name="Lang_ChineseSimplified" xml:space="preserve">
+    <value>簡體中文</value>
+  </data>
+  <data name="Lang_ChineseTraditional" xml:space="preserve">
+    <value>繁體中文</value>
+  </data>
+  <data name="Lang_Korean" xml:space="preserve">
+    <value>韓語</value>
+  </data>
+  <data name="Lang_French" xml:space="preserve">
+    <value>法語</value>
+  </data>
+  <data name="Lang_German" xml:space="preserve">
+    <value>德語</value>
+  </data>
+  <data name="Lang_Italian" xml:space="preserve">
+    <value>義大利語</value>
+  </data>
+  <data name="Lang_Spanish" xml:space="preserve">
+    <value>西班牙語</value>
+  </data>
+  <data name="Lang_Portuguese" xml:space="preserve">
+    <value>葡萄牙語</value>
+  </data>
+  <data name="Lang_ChineseVariant_Simplified" xml:space="preserve">
+    <value>簡體</value>
+  </data>
+  <data name="Lang_ChineseVariant_Traditional" xml:space="preserve">
+    <value>繁體</value>
+  </data>
+  <data name="Lang_ChineseVariant_Auto" xml:space="preserve">
+    <value>自動</value>
+  </data>
+  <data name="Lang_ChineseVariant_Cantonese" xml:space="preserve">
+    <value>粵語</value>
+  </data>
+  <data name="Lang_TranslationStrategy_TwoStage" xml:space="preserve">
+    <value>（兩階段翻譯）</value>
+  </data>
+
 </root>

--- a/Baketa.UI/ViewModels/MainOverlayViewModel.cs
+++ b/Baketa.UI/ViewModels/MainOverlayViewModel.cs
@@ -783,10 +783,25 @@ public class MainOverlayViewModel : ViewModelBase
     /// </summary>
     private void OnLanguageChanged(object? sender, LanguageChangedEventArgs e)
     {
-        this.RaisePropertyChanged(nameof(SingleshotButtonText));
-        this.RaisePropertyChanged(nameof(SingleshotButtonTooltip));
-        this.RaisePropertyChanged(nameof(LiveButtonText));
-        this.RaisePropertyChanged(nameof(InitializationText));
+        // [Issue #528] LanguageChangedイベントはConfigureAwait(false)後の非UIスレッドから
+        // 発火される可能性があるため、UIスレッドにディスパッチする
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            this.RaisePropertyChanged(nameof(SingleshotButtonText));
+            this.RaisePropertyChanged(nameof(SingleshotButtonTooltip));
+            this.RaisePropertyChanged(nameof(LiveButtonText));
+            this.RaisePropertyChanged(nameof(InitializationText));
+
+            // StartButtonTooltipはstored valueのため、言語変更時にStringsから再取得
+            if (_warmupService.Status == Baketa.Core.Abstractions.GPU.WarmupStatus.Failed)
+            {
+                StartButtonTooltip = Strings.MainOverlay_Warmup_Failed;
+            }
+            else if (_warmupService.IsWarmupCompleted)
+            {
+                StartButtonTooltip = Strings.MainOverlay_StartButton_Tooltip;
+            }
+        });
     }
 
     public string InitializationText => CurrentStatus switch

--- a/Baketa.UI/ViewModels/Settings/GeneralSettingsViewModel.cs
+++ b/Baketa.UI/ViewModels/Settings/GeneralSettingsViewModel.cs
@@ -58,9 +58,10 @@ public sealed class GeneralSettingsViewModel : Framework.ViewModelBase
 
     // 翻訳設定用バッキングフィールド
     private bool _useLocalEngine = true;
-    private string _sourceLanguage = "Japanese";
-    private string _targetLanguage = "English";
+    private string _sourceLanguage = "en";
+    private string _targetLanguage = "ja";
     private int _fontSize = 14;
+    private bool _isUpdatingLanguages;
 
     // [Issue #78 Phase 5] Cloud AI使用量表示用バッキングフィールド
     private long _cloudTokensUsed;
@@ -315,6 +316,7 @@ public sealed class GeneralSettingsViewModel : Framework.ViewModelBase
         get => _sourceLanguage;
         set
         {
+            if (_isUpdatingLanguages) return;
             this.RaiseAndSetIfChanged(ref _sourceLanguage, value);
             UpdateAvailableTargetLanguages();
         }
@@ -326,7 +328,11 @@ public sealed class GeneralSettingsViewModel : Framework.ViewModelBase
     public string TargetLanguage
     {
         get => _targetLanguage;
-        set => this.RaiseAndSetIfChanged(ref _targetLanguage, value);
+        set
+        {
+            if (_isUpdatingLanguages && value is null) return;
+            this.RaiseAndSetIfChanged(ref _targetLanguage, value);
+        }
     }
 
     /// <summary>
@@ -339,13 +345,11 @@ public sealed class GeneralSettingsViewModel : Framework.ViewModelBase
     }
 
     /// <summary>
-    /// 利用可能な言語リスト
+    /// 利用可能な言語リスト（言語コード）
     /// </summary>
     public ObservableCollection<string> AvailableLanguages { get; } =
     [
-        "Japanese", "English",
-        "Chinese (Simplified)", "Chinese (Traditional)",
-        "Korean", "French", "German", "Italian", "Spanish", "Portuguese"
+        "ja", "en", "zh-CN", "zh-TW", "ko", "fr", "de", "it", "es", "pt"
     ];
 
     /// <summary>
@@ -511,6 +515,11 @@ public sealed class GeneralSettingsViewModel : Framework.ViewModelBase
     public IReadOnlyList<UiTheme> AvailableThemes { get; } = [UiTheme.Light, UiTheme.Dark, UiTheme.Auto];
 
     /// <summary>
+    /// [Issue #527] 言語コードからローカライズされた表示名を取得
+    /// </summary>
+    public static string GetLanguageDisplayName(string code) => Models.AvailableLanguages.GetLocalizedDisplayName(code);
+
+    /// <summary>
     /// テーマ表示名を取得
     /// </summary>
     public static string GetThemeDisplayName(UiTheme theme) => theme switch
@@ -645,9 +654,9 @@ public sealed class GeneralSettingsViewModel : Framework.ViewModelBase
     /// </summary>
     private void InitializeFromTranslationSettings(TranslationSettings settings)
     {
-        // 翻訳言語の復元（言語コードから表示名に変換）
-        _sourceLanguage = Baketa.Core.Utilities.LanguageCodeConverter.ToDisplayName(settings.DefaultSourceLanguage, "English");
-        _targetLanguage = Baketa.Core.Utilities.LanguageCodeConverter.ToDisplayName(settings.DefaultTargetLanguage, "English");
+        // [Issue #527] 言語コードを直接使用（表示名変換はUI側のConverterで行う）
+        _sourceLanguage = settings.DefaultSourceLanguage ?? "en";
+        _targetLanguage = settings.DefaultTargetLanguage ?? "ja";
         _fontSize = settings.OverlayFontSize;
 
         // [Issue #78 Phase 5] Cloud AI翻訳設定の復元
@@ -869,21 +878,35 @@ public sealed class GeneralSettingsViewModel : Framework.ViewModelBase
     /// </summary>
     private void UpdateAvailableTargetLanguages()
     {
-        AvailableTargetLanguages.Clear();
-
-        // ソース言語以外の全言語をターゲット言語として追加
-        foreach (var lang in AvailableLanguages)
+        if (_isUpdatingLanguages) return;
+        _isUpdatingLanguages = true;
+        try
         {
-            if (!string.Equals(lang, SourceLanguage, StringComparison.Ordinal))
+            var previousTarget = TargetLanguage;
+            AvailableTargetLanguages.Clear();
+
+            // ソース言語以外の全言語をターゲット言語として追加
+            foreach (var lang in AvailableLanguages)
             {
-                AvailableTargetLanguages.Add(lang);
+                if (!string.Equals(lang, SourceLanguage, StringComparison.Ordinal))
+                {
+                    AvailableTargetLanguages.Add(lang);
+                }
+            }
+
+            // 現在の翻訳先言語が選択肢にある場合は維持、なければ最初の選択肢を選択
+            if (AvailableTargetLanguages.Contains(previousTarget))
+            {
+                TargetLanguage = previousTarget;
+            }
+            else if (AvailableTargetLanguages.Count > 0)
+            {
+                TargetLanguage = AvailableTargetLanguages.First();
             }
         }
-
-        // 現在の翻訳先言語が選択肢にない場合は最初の選択肢を選択
-        if (!AvailableTargetLanguages.Contains(TargetLanguage) && AvailableTargetLanguages.Count > 0)
+        finally
         {
-            TargetLanguage = AvailableTargetLanguages.First();
+            _isUpdatingLanguages = false;
         }
     }
 
@@ -983,9 +1006,9 @@ public sealed class GeneralSettingsViewModel : Framework.ViewModelBase
         get
         {
             var settings = _originalTranslationSettings.Clone();
-            // 表示名から言語コードに変換
-            settings.DefaultSourceLanguage = Baketa.Core.Utilities.LanguageCodeConverter.ToLanguageCode(SourceLanguage, "en");
-            settings.DefaultTargetLanguage = Baketa.Core.Utilities.LanguageCodeConverter.ToLanguageCode(TargetLanguage, "en");
+            // [Issue #527] 言語コードを直接使用（変換不要）
+            settings.DefaultSourceLanguage = SourceLanguage ?? "en";
+            settings.DefaultTargetLanguage = TargetLanguage ?? "ja";
             settings.OverlayFontSize = FontSize;
             // [Issue #78 Phase 5] + [Issue #280+#281] Cloud AI翻訳設定を反映
             // UseLocalEngine=true(ローカル翻訳) → EnableCloudAiTranslation=false

--- a/Baketa.UI/Views/Settings/GeneralSettingsView.axaml
+++ b/Baketa.UI/Views/Settings/GeneralSettingsView.axaml
@@ -101,14 +101,26 @@
                         <StackPanel Orientation="Horizontal" Spacing="12">
                             <ComboBox ItemsSource="{Binding AvailableLanguages}"
                                       SelectedItem="{Binding SourceLanguage}"
-                                      Width="120"/>
+                                      Width="150">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate x:DataType="x:String">
+                                        <TextBlock Text="{Binding Converter={x:Static converters:LanguageCodeToDisplayNameConverter.Instance}}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
                             <TextBlock Text="→"
                                        VerticalAlignment="Center"
                                        FontWeight="Bold"
                                        Foreground="{DynamicResource AccentFillColorDefaultBrush}"/>
                             <ComboBox ItemsSource="{Binding AvailableTargetLanguages}"
                                       SelectedItem="{Binding TargetLanguage}"
-                                      Width="120"/>
+                                      Width="150">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate x:DataType="x:String">
+                                        <TextBlock Text="{Binding Converter={x:Static converters:LanguageCodeToDisplayNameConverter.Instance}}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
                         </StackPanel>
                     </controls:SettingsItem.SettingContent>
                 </controls:SettingsItem>


### PR DESCRIPTION
## Summary
- **#527**: 翻訳言語ComboBoxの表示名をUI言語に応じてローカライズ表示するように変更
- **#528**: UI言語変更時にStartButtonTooltipが更新されない問題を修正し、非UIスレッドからのプロパティ変更通知によるAccess Violationクラッシュも解消

## 変更内容

### #527: 翻訳言語ComboBoxのi18n対応
- `AvailableLanguages`を表示名（"Japanese"/"English"）から言語コード（"ja"/"en"）に変更
- `LanguageCodeToDisplayNameConverter`を追加し、ComboBoxの`ItemTemplate`で表示時にローカライズ
- `AvailableLanguages.GetLocalizedDisplayName()`で`Strings.resx`から動的に表示名取得
- 10言語×16キーの`Lang_*`リソースを全resxファイルに追加
- `ObservableCollection.Clear()`時のnull設定対策として再帰ガード追加

### #528: StartButtonTooltip言語切替 + スレッド安全性修正
- `OnLanguageChanged`を`Dispatcher.UIThread.Post()`でラップ
- `ConfigureAwait(false)`後の非UIスレッドからの`RaisePropertyChanged`呼び出しによるAccess Violation（0xc0000005）を修正
- ウォームアップ状態に応じて`StartButtonTooltip`を`Strings`から再取得

## Test plan
- [x] ビルド成功確認
- [x] 既存テスト全パス（433 passed, 30 skipped）
- [x] UI言語変更して保存 → クラッシュしないことを確認
- [x] 翻訳言語ComboBoxがUI言語に応じたローカライズ表示になることを確認
- [x] 翻訳言語変更して保存 → 正常に保存されることを確認
- [x] StartButtonTooltipがUI言語変更後に更新されることを確認
- [x] Geminiコードレビュー完了（重大な問題なし）

Closes #527
Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)