### PR TITLE
feat(#497): ファントムカーソル機能を実装

### DIFF
--- a/Baketa.Application/DI/Modules/ApplicationModule.cs
+++ b/Baketa.Application/DI/Modules/ApplicationModule.cs
@@ -450,6 +450,20 @@ public sealed class ApplicationModule : ServiceModuleBase
         });
         services.AddHostedService(provider => provider.GetRequiredService<Services.Learning.RoiMonitoringHostedService>());
 
+        // [Issue #497] ファントムカーソルサービス
+        services.AddSingleton<Services.Cursor.PhantomCursorHostedService>(provider =>
+        {
+            return new Services.Cursor.PhantomCursorHostedService(
+                provider.GetService<Services.UI.IWindowManagementService>(),
+                provider.GetService<Baketa.Core.Abstractions.Services.ICursorStateProvider>(),
+                provider.GetService<Func<Microsoft.Extensions.Logging.ILogger, Baketa.Core.Abstractions.Services.IPhantomCursorWindowAdapter>>(),
+                provider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<Services.Cursor.PhantomCursorHostedService>>()
+            );
+        });
+        services.AddSingleton<Baketa.Core.Abstractions.Services.IPhantomCursorService>(
+            provider => provider.GetRequiredService<Services.Cursor.PhantomCursorHostedService>());
+        services.AddHostedService(provider => provider.GetRequiredService<Services.Cursor.PhantomCursorHostedService>());
+
         // 統合サービス
         // 例: services.AddSingleton<ITranslationIntegrationService, TranslationIntegrationService>();
 

--- a/Baketa.Application/Services/Cursor/PhantomCursorHostedService.cs
+++ b/Baketa.Application/Services/Cursor/PhantomCursorHostedService.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Baketa.Application.Services.UI;
+using Baketa.Core.Abstractions.Services;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Baketa.Application.Services.Cursor;
+
+/// <summary>
+/// [Issue #497] ファントムカーソル監視HostedService
+/// ゲームがシステムカーソルを非表示にしている場合に代替カーソルを表示する
+/// </summary>
+/// <remarks>
+/// 監視ループで以下の3条件をチェック:
+/// 1. システムカーソルが非表示（CURSORINFO.flags に CURSOR_SHOWING なし）
+/// 2. 翻訳対象ウィンドウまたはBaketa自身がフォアグラウンド
+/// 3. マウス座標がゲームウィンドウのクライアント領域内
+/// </remarks>
+public sealed class PhantomCursorHostedService : BackgroundService, IPhantomCursorService
+{
+    private readonly IWindowManagementService? _windowManagementService;
+    private readonly ICursorStateProvider? _cursorStateProvider;
+    private readonly ILogger<PhantomCursorHostedService> _logger;
+
+    private readonly Func<ILogger, IPhantomCursorWindowAdapter>? _windowFactory;
+    private IPhantomCursorWindowAdapter? _cursorWindow;
+
+    private nint _targetWindowHandle;
+    private bool _isEnabled = true; // デフォルトON
+    private bool _wasShowing;
+
+    // マウス静止検出
+    private int _lastMouseX;
+    private int _lastMouseY;
+    private int _staticFrameCount;
+    private const int StaticThresholdFrames = 6; // ~100ms at 16ms interval
+
+    private const int PollingIntervalMs = 16; // ~60FPS
+
+    public PhantomCursorHostedService(
+        IWindowManagementService? windowManagementService,
+        ICursorStateProvider? cursorStateProvider,
+        Func<ILogger, IPhantomCursorWindowAdapter>? windowFactory,
+        ILogger<PhantomCursorHostedService> logger)
+    {
+        _windowManagementService = windowManagementService;
+        _cursorStateProvider = cursorStateProvider;
+        _windowFactory = windowFactory;
+        _logger = logger;
+
+        _windowManagementService?.WindowSelectionChanged.Subscribe(OnWindowSelectionChanged);
+    }
+
+    public bool IsEnabled => _isEnabled;
+
+    public void SetTargetWindow(nint windowHandle)
+    {
+        _targetWindowHandle = windowHandle;
+        _logger.LogDebug("[Issue #497] Target window set: 0x{Handle:X}", windowHandle);
+    }
+
+    public void Enable()
+    {
+        _isEnabled = true;
+        _logger.LogInformation("[Issue #497] PhantomCursor enabled");
+    }
+
+    public void Disable()
+    {
+        _isEnabled = false;
+        _cursorWindow?.Hide();
+        _logger.LogInformation("[Issue #497] PhantomCursor disabled");
+    }
+
+    private void OnWindowSelectionChanged(WindowSelectionChanged change)
+    {
+        if (change.CurrentWindow is not null)
+        {
+            _logger.LogInformation("[Issue #497] Target window: \"{Title}\" (0x{Handle:X})",
+                change.CurrentWindow.Title, change.CurrentWindow.Handle);
+            SetTargetWindow(change.CurrentWindow.Handle);
+        }
+        else
+        {
+            _targetWindowHandle = IntPtr.Zero;
+            _cursorWindow?.Hide();
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("[Issue #497] PhantomCursorHostedService starting");
+
+        if (_cursorStateProvider is null)
+        {
+            _logger.LogWarning("[Issue #497] ICursorStateProvider not available, PhantomCursor disabled");
+            return;
+        }
+
+        // 初期化遅延（アプリケーション起動を妨げない）
+        await Task.Delay(2000, stoppingToken).ConfigureAwait(false);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (_isEnabled && _targetWindowHandle != IntPtr.Zero)
+                {
+                    ProcessCursorState();
+                }
+
+                await Task.Delay(PollingIntervalMs, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[Issue #497] PhantomCursor monitoring error");
+                await Task.Delay(1000, stoppingToken).ConfigureAwait(false);
+            }
+        }
+
+        _cursorWindow?.Dispose();
+        _cursorWindow = null;
+
+        _logger.LogInformation("[Issue #497] PhantomCursorHostedService stopped");
+    }
+
+    private void ProcessCursorState()
+    {
+        var shouldShow = ShouldShowPhantomCursor(out var screenX, out var screenY);
+
+        if (shouldShow)
+        {
+            if (screenX == _lastMouseX && screenY == _lastMouseY)
+            {
+                _staticFrameCount++;
+                if (_staticFrameCount > StaticThresholdFrames)
+                    return; // 静止中は描画更新スキップ
+            }
+            else
+            {
+                _staticFrameCount = 0;
+                _lastMouseX = screenX;
+                _lastMouseY = screenY;
+            }
+
+            EnsureCursorWindow();
+            _cursorWindow?.UpdatePosition(screenX, screenY);
+            _cursorWindow?.Show();
+
+            if (!_wasShowing)
+            {
+                var state = _cursorStateProvider!.GetCursorState();
+                _logger.LogInformation(
+                    "[Issue #497] PhantomCursor shown - HiddenType: {HiddenType}, flags: 0x{Flags:X}, hCursor: 0x{Cursor:X}",
+                    state.HiddenType, state.Flags, state.CursorHandle);
+                _wasShowing = true;
+            }
+        }
+        else
+        {
+            _cursorWindow?.Hide();
+            _staticFrameCount = 0;
+
+            if (_wasShowing)
+            {
+                _logger.LogDebug("[Issue #497] PhantomCursor hidden");
+                _wasShowing = false;
+            }
+        }
+    }
+
+    private bool ShouldShowPhantomCursor(out int screenX, out int screenY)
+    {
+        screenX = 0;
+        screenY = 0;
+
+        if (_cursorStateProvider is null)
+            return false;
+
+        var state = _cursorStateProvider.GetCursorState();
+
+        // 条件1: システムカーソルが非表示か
+        if (!state.IsHidden)
+        {
+            screenX = state.ScreenX;
+            screenY = state.ScreenY;
+            return false;
+        }
+
+        screenX = state.ScreenX;
+        screenY = state.ScreenY;
+
+        // 条件2: 翻訳対象ウィンドウまたはBaketaがフォアグラウンドか
+        if (!_cursorStateProvider.IsWindowForeground(_targetWindowHandle))
+            return false;
+
+        // 条件3: マウスが対象ウィンドウのクライアント領域内か
+        if (!_cursorStateProvider.IsPointInClientArea(_targetWindowHandle, screenX, screenY))
+            return false;
+
+        return true;
+    }
+
+    private void EnsureCursorWindow()
+    {
+        if (_cursorWindow is not null) return;
+
+        try
+        {
+            _cursorWindow = _windowFactory?.Invoke(_logger);
+            _logger.LogInformation("[Issue #497] PhantomCursorWindow created");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Issue #497] Failed to create PhantomCursorWindow");
+        }
+    }
+
+    public override void Dispose()
+    {
+        _cursorWindow?.Dispose();
+        _cursorWindow = null;
+        base.Dispose();
+    }
+}

--- a/Baketa.Core/Abstractions/Services/ICursorStateProvider.cs
+++ b/Baketa.Core/Abstractions/Services/ICursorStateProvider.cs
@@ -1,0 +1,62 @@
+namespace Baketa.Core.Abstractions.Services;
+
+/// <summary>
+/// [Issue #497] カーソル状態の詳細情報
+/// </summary>
+public readonly record struct CursorState(
+    bool IsHidden,
+    int ScreenX,
+    int ScreenY,
+    uint Flags,
+    nint CursorHandle)
+{
+    /// <summary>
+    /// カーソル非表示の推定タイプ
+    /// </summary>
+    public CursorHiddenType HiddenType => IsHidden switch
+    {
+        false => CursorHiddenType.NotHidden,
+        true when CursorHandle == 0 => CursorHiddenType.SetCursorNull,
+        true => CursorHiddenType.ShowCursorFalse
+    };
+}
+
+/// <summary>
+/// カーソル非表示の推定タイプ
+/// </summary>
+public enum CursorHiddenType
+{
+    /// <summary>カーソルは表示されている</summary>
+    NotHidden,
+    /// <summary>ShowCursor(FALSE) でカウンタが0未満（flags=0, hCursor≠NULL）</summary>
+    ShowCursorFalse,
+    /// <summary>SetCursor(NULL) でカーソルリソースがnull（hCursor=NULL）</summary>
+    SetCursorNull
+}
+
+/// <summary>
+/// [Issue #497] カーソル状態を提供するインターフェース
+/// Platform層のP/Invoke呼び出しを抽象化する
+/// </summary>
+public interface ICursorStateProvider
+{
+    /// <summary>
+    /// システムカーソルが非表示かどうかを取得し、現在のスクリーン座標を返す
+    /// </summary>
+    bool IsCursorHidden(out int screenX, out int screenY);
+
+    /// <summary>
+    /// カーソル状態の詳細情報を取得
+    /// </summary>
+    CursorState GetCursorState();
+
+    /// <summary>
+    /// 指定ウィンドウがフォアグラウンドかどうか
+    /// </summary>
+    bool IsWindowForeground(nint windowHandle);
+
+    /// <summary>
+    /// 指定スクリーン座標がウィンドウのクライアント領域内かどうか
+    /// </summary>
+    bool IsPointInClientArea(nint windowHandle, int screenX, int screenY);
+}

--- a/Baketa.Core/Abstractions/Services/IPhantomCursorService.cs
+++ b/Baketa.Core/Abstractions/Services/IPhantomCursorService.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace Baketa.Core.Abstractions.Services;
+
+/// <summary>
+/// [Issue #497] ファントムカーソルサービスのインターフェース
+/// ゲーム側がカーソルを非表示にしている場合に代替カーソルを表示する
+/// </summary>
+public interface IPhantomCursorService
+{
+    /// <summary>
+    /// 監視対象のゲームウィンドウハンドルを設定
+    /// </summary>
+    void SetTargetWindow(nint windowHandle);
+
+    /// <summary>
+    /// ファントムカーソル機能を有効化
+    /// </summary>
+    void Enable();
+
+    /// <summary>
+    /// ファントムカーソル機能を無効化
+    /// </summary>
+    void Disable();
+
+    /// <summary>
+    /// 現在有効かどうか
+    /// </summary>
+    bool IsEnabled { get; }
+}
+
+/// <summary>
+/// [Issue #497] ファントムカーソルウィンドウの抽象化（Platform層から注入）
+/// </summary>
+public interface IPhantomCursorWindowAdapter : IDisposable
+{
+    void UpdatePosition(int screenX, int screenY);
+    void Show();
+    void Hide();
+}

--- a/Baketa.Infrastructure.Platform/DI/Modules/OverlayModule.cs
+++ b/Baketa.Infrastructure.Platform/DI/Modules/OverlayModule.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Runtime.Versioning;
+using Baketa.Core.Abstractions.Services;
 using Baketa.Core.Abstractions.UI.Overlays;
 using Baketa.Core.UI.Overlay;
 using Baketa.Infrastructure.Platform.Windows.Overlay;
@@ -46,6 +48,10 @@ public static class OverlayModule
         // 🎯 [OVERLAY_UNIFICATION] 統一オーバーレイマネージャー登録
         // Application層が依存するIOverlayManager実装
         services.AddSingleton<IOverlayManager, Win32OverlayManager>();
+
+        // [Issue #497] ファントムカーソルウィンドウファクトリ
+        services.AddSingleton<Func<ILogger, IPhantomCursorWindowAdapter>>(
+            _ => loggerArg => new PhantomCursorWindowAdapter(loggerArg));
 
         logger.LogInformation("✅ [OVERLAY_UNIFICATION] Win32オーバーレイシステム登録完了");
         logger.LogDebug("   - LayeredOverlayWindowFactory → ILayeredOverlayWindowFactory");

--- a/Baketa.Infrastructure.Platform/DI/Modules/PlatformModule.cs
+++ b/Baketa.Infrastructure.Platform/DI/Modules/PlatformModule.cs
@@ -172,6 +172,10 @@ public class PlatformModule : ServiceModuleBase
             Baketa.Infrastructure.Platform.Windows.Credentials.WindowsCredentialStorage>();
         Console.WriteLine("✅ WindowsCredentialStorage登録完了 - 認証トークンの安全な永続化");
 
+        // [Issue #497] カーソル状態プロバイダー（ファントムカーソル用）
+        services.AddSingleton<Baketa.Core.Abstractions.Services.ICursorStateProvider,
+            Baketa.Infrastructure.Platform.Windows.Services.CursorStateProvider>();
+
         // その他のWindows API関連サービス
         // 例: services.AddSingleton<IWindowsProcessService, WindowsProcessService>();
         // 例: services.AddSingleton<IHotkeyService, Win32HotkeyService>();

--- a/Baketa.Infrastructure.Platform/Windows/NativeMethods/CommonStructures.cs
+++ b/Baketa.Infrastructure.Platform/Windows/NativeMethods/CommonStructures.cs
@@ -242,6 +242,25 @@ internal struct WNDCLASS
 }
 
 /// <summary>
+/// [Issue #497] CURSORINFO構造体 - GetCursorInfo用
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct CURSORINFO
+{
+    public uint cbSize;
+    public uint flags;
+    public IntPtr hCursor;
+    public POINT ptScreenPos;
+
+    public const uint CURSOR_SHOWING = 0x00000001;
+
+    public static CURSORINFO Create() => new()
+    {
+        cbSize = (uint)Marshal.SizeOf<CURSORINFO>()
+    };
+}
+
+/// <summary>
 /// 🔥 [DWM_BLUR_IMPLEMENTATION] PAINTSTRUCT構造体
 /// </summary>
 /// <remarks>

--- a/Baketa.Infrastructure.Platform/Windows/NativeMethods/User32Methods.cs
+++ b/Baketa.Infrastructure.Platform/Windows/NativeMethods/User32Methods.cs
@@ -210,6 +210,22 @@ internal static class User32Methods
     // 🔥 [ACRYLIC_BLUR] SetWindowCompositionAttribute for Windows 10/11 Blur/Acrylic
     [DllImport(USER32_DLL, SetLastError = false)]
     internal static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
+
+    // [Issue #497] カーソル情報取得API
+    [DllImport(USER32_DLL, SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetCursorInfo(ref CURSORINFO pci);
+
+    [DllImport(USER32_DLL, SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetClientRect(IntPtr hWnd, out RECT lpRect);
+
+    [DllImport(USER32_DLL, SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool ScreenToClient(IntPtr hWnd, ref POINT lpPoint);
+
+    [DllImport(USER32_DLL, SetLastError = true, ExactSpelling = true)]
+    internal static extern IntPtr WindowFromPoint(POINT point);
 }
 
 [Flags]

--- a/Baketa.Infrastructure.Platform/Windows/Overlay/PhantomCursorWindow.cs
+++ b/Baketa.Infrastructure.Platform/Windows/Overlay/PhantomCursorWindow.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Collections.Concurrent;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Threading;
+using Baketa.Infrastructure.Platform.Windows.NativeMethods;
+using Microsoft.Extensions.Logging;
+
+namespace Baketa.Infrastructure.Platform.Windows.Overlay;
+
+/// <summary>
+/// [Issue #497] ファントムカーソル描画用の軽量LayeredWindowオーバーレイ
+/// </summary>
+/// <remarks>
+/// ゲーム側がシステムカーソルを非表示にしている場合に、
+/// 半透明の円形カーソルを代替表示する。
+/// LayeredOverlayWindowパターンを踏襲: STAスレッド + GDI32描画 + UpdateLayeredWindow
+/// </remarks>
+[SupportedOSPlatform("windows")]
+internal sealed class PhantomCursorWindow : IDisposable
+{
+    private readonly ILogger _logger;
+
+    private readonly Thread _windowThread;
+    private IntPtr _hwnd = IntPtr.Zero;
+    private readonly ManualResetEventSlim _windowCreatedEvent = new(false);
+    private readonly BlockingCollection<Action> _messageQueue = new();
+    private bool _disposed;
+    private bool _updatePending;
+    private bool _isVisible;
+
+    // カーソル描画パラメータ
+    private const int CursorDiameter = 30;
+    private const int BitmapSize = CursorDiameter + 4; // 外側境界線のマージン
+    private const byte CursorAlpha = 153; // ~60% 不透明度
+
+    // GDIリソース
+    private IntPtr _hdcScreen;
+    private IntPtr _hdcMem;
+    private IntPtr _hBitmap;
+    private IntPtr _hOldBitmap;
+
+    // ウィンドウクラス
+    private const string WindowClassName = "BaketaPhantomCursor";
+    private static ushort _windowClassAtom;
+    private static readonly object _classLock = new();
+    private static WndProcDelegate? _wndProcDelegate;
+
+    private const uint WM_USER = 0x0400;
+    private const uint WM_PROCESS_QUEUE = WM_USER + 2;
+    private const uint WM_NCHITTEST = 0x0084;
+    private const nint HTTRANSPARENT = -1;
+
+    public PhantomCursorWindow(ILogger logger)
+    {
+        _logger = logger;
+
+        _windowThread = new Thread(WindowThreadProc)
+        {
+            Name = "PhantomCursor STA Thread",
+            IsBackground = true
+        };
+        _windowThread.SetApartmentState(ApartmentState.STA);
+        _windowThread.Start();
+
+        if (!_windowCreatedEvent.Wait(TimeSpan.FromSeconds(5)))
+            throw new InvalidOperationException("PhantomCursorWindow creation timeout");
+
+        if (_hwnd == IntPtr.Zero)
+            throw new InvalidOperationException("PhantomCursorWindow HWND is null");
+
+        // 初回描画（円形カーソルのビットマップを一度だけ作成）
+        _messageQueue.Add(DrawCursorBitmap);
+        TriggerMessageQueueProcessing();
+
+        _logger.LogDebug("[Issue #497] PhantomCursorWindow created - HWND: 0x{Hwnd:X}", _hwnd.ToInt64());
+    }
+
+    private void WindowThreadProc()
+    {
+        try
+        {
+            RegisterWindowClass();
+            CreateWindow();
+
+            if (_hwnd == IntPtr.Zero)
+            {
+                _windowCreatedEvent.Set();
+                return;
+            }
+
+            _windowCreatedEvent.Set();
+
+            while (LayeredWindowMethods.GetMessage(out var msg, IntPtr.Zero, 0, 0))
+            {
+                LayeredWindowMethods.TranslateMessage(ref msg);
+                LayeredWindowMethods.DispatchMessage(ref msg);
+
+                while (_messageQueue.TryTake(out var action, 0))
+                {
+                    try { action(); }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "[Issue #497] PhantomCursor message queue error");
+                    }
+                }
+                _updatePending = false;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Issue #497] PhantomCursor thread error");
+            _windowCreatedEvent.Set();
+        }
+        finally
+        {
+            CleanupGdiResources();
+        }
+    }
+
+    private void RegisterWindowClass()
+    {
+        lock (_classLock)
+        {
+            if (_windowClassAtom != 0) return;
+
+            _wndProcDelegate = new WndProcDelegate(WndProc);
+            var wndProcPtr = Marshal.GetFunctionPointerForDelegate(_wndProcDelegate);
+
+            var wndClass = new WNDCLASS
+            {
+                lpfnWndProc = wndProcPtr,
+                hInstance = User32Methods.GetModuleHandle(null),
+                lpszClassName = WindowClassName,
+                hCursor = IntPtr.Zero,
+                hbrBackground = IntPtr.Zero,
+            };
+
+            _windowClassAtom = User32Methods.RegisterClass(ref wndClass);
+            if (_windowClassAtom == 0)
+                throw new InvalidOperationException($"RegisterClass failed for {WindowClassName}");
+        }
+    }
+
+    private void CreateWindow()
+    {
+        const uint exStyle = LayeredWindowMethods.WS_EX_LAYERED
+                           | (uint)ExtendedWindowStyles.WS_EX_TRANSPARENT
+                           | LayeredWindowMethods.WS_EX_NOACTIVATE
+                           | (uint)ExtendedWindowStyles.WS_EX_TOPMOST
+                           | (uint)ExtendedWindowStyles.WS_EX_TOOLWINDOW;
+
+        _hwnd = User32Methods.CreateWindowEx(
+            exStyle,
+            _windowClassAtom,
+            "Baketa PhantomCursor",
+            (uint)WindowStyles.WS_POPUP,
+            0, 0, BitmapSize, BitmapSize,
+            IntPtr.Zero, IntPtr.Zero,
+            User32Methods.GetModuleHandle(null),
+            IntPtr.Zero);
+    }
+
+    private static IntPtr WndProc(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam)
+    {
+        if (msg == WM_NCHITTEST)
+            return HTTRANSPARENT;
+        return User32Methods.DefWindowProc(hwnd, msg, wParam, lParam);
+    }
+
+    /// <summary>
+    /// カーソルビットマップを描画（円形二重縁取り）
+    /// </summary>
+    private void DrawCursorBitmap()
+    {
+        if (_hwnd == IntPtr.Zero) return;
+
+        try
+        {
+            CleanupGdiResources();
+
+            _hdcScreen = User32Methods.GetDC(IntPtr.Zero);
+            if (_hdcScreen == IntPtr.Zero) return;
+
+            _hdcMem = LayeredWindowMethods.CreateCompatibleDC(_hdcScreen);
+            if (_hdcMem == IntPtr.Zero) return;
+
+            var bmi = new BITMAPINFO
+            {
+                bmiHeader = BITMAPINFOHEADER.Create32BitARGB(BitmapSize, BitmapSize),
+                bmiColors = new uint[1]
+            };
+
+            _hBitmap = LayeredWindowMethods.CreateDIBSection(
+                _hdcMem, ref bmi, LayeredWindowMethods.DIB_RGB_COLORS,
+                out _, IntPtr.Zero, 0);
+            if (_hBitmap == IntPtr.Zero) return;
+
+            _hOldBitmap = LayeredWindowMethods.SelectObject(_hdcMem, _hBitmap);
+
+            using (var g = Graphics.FromHdc(_hdcMem))
+            {
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+
+                var offset = (BitmapSize - CursorDiameter) / 2;
+                var outerRect = new Rectangle(offset, offset, CursorDiameter - 1, CursorDiameter - 1);
+                var innerRect = new Rectangle(offset + 2, offset + 2, CursorDiameter - 5, CursorDiameter - 5);
+
+                // 外側: 黒縁（1px）
+                using var outerPen = new Pen(Color.FromArgb(CursorAlpha, 0, 0, 0), 1.5f);
+                g.DrawEllipse(outerPen, outerRect);
+
+                // 内側: 白縁（1px）
+                using var innerPen = new Pen(Color.FromArgb(CursorAlpha, 255, 255, 255), 1.5f);
+                g.DrawEllipse(innerPen, innerRect);
+
+                // 中央点
+                var centerSize = 4;
+                var cx = BitmapSize / 2 - centerSize / 2;
+                var cy = BitmapSize / 2 - centerSize / 2;
+                using var centerBrush = new SolidBrush(Color.FromArgb(CursorAlpha, 255, 255, 255));
+                g.FillEllipse(centerBrush, cx, cy, centerSize, centerSize);
+            }
+
+            // UpdateLayeredWindowで描画内容を適用（位置は後で更新するので0,0）
+            ApplyLayeredContent(0, 0);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[Issue #497] DrawCursorBitmap error");
+        }
+    }
+
+    /// <summary>
+    /// カーソル位置を更新（スクリーン座標）
+    /// </summary>
+    public void UpdatePosition(int screenX, int screenY)
+    {
+        if (_disposed || _hwnd == IntPtr.Zero) return;
+
+        // カーソルの中心がマウス位置に来るようにオフセット
+        var x = screenX - BitmapSize / 2;
+        var y = screenY - BitmapSize / 2;
+
+        _messageQueue.Add(() =>
+        {
+            if (_hwnd == IntPtr.Zero) return;
+            ApplyLayeredContent(x, y);
+        });
+        TriggerMessageQueueProcessing();
+    }
+
+    private void ApplyLayeredContent(int x, int y)
+    {
+        if (_hdcMem == IntPtr.Zero || _hdcScreen == IntPtr.Zero) return;
+
+        var pptDst = new NativeMethods.POINT(x, y);
+        var psize = new NativeMethods.SIZE(BitmapSize, BitmapSize);
+        var pptSrc = new NativeMethods.POINT(0, 0);
+
+        var blend = new NativeMethods.BLENDFUNCTION
+        {
+            BlendOp = 0,
+            BlendFlags = 0,
+            SourceConstantAlpha = 255,
+            AlphaFormat = 1
+        };
+
+        LayeredWindowMethods.UpdateLayeredWindow(
+            _hwnd, _hdcScreen, ref pptDst, ref psize,
+            _hdcMem, ref pptSrc, 0, ref blend,
+            UpdateLayeredWindowFlags.ULW_ALPHA);
+    }
+
+    public void Show()
+    {
+        if (_disposed || _isVisible) return;
+
+        _messageQueue.Add(() =>
+        {
+            if (_hwnd != IntPtr.Zero && !_isVisible)
+            {
+                LayeredWindowMethods.ShowWindow(_hwnd, ShowWindowCommands.SW_SHOWNOACTIVATE);
+                _isVisible = true;
+            }
+        });
+        TriggerMessageQueueProcessing();
+    }
+
+    public void Hide()
+    {
+        if (_disposed || !_isVisible) return;
+
+        _messageQueue.Add(() =>
+        {
+            if (_hwnd != IntPtr.Zero && _isVisible)
+            {
+                LayeredWindowMethods.ShowWindow(_hwnd, ShowWindowCommands.SW_HIDE);
+                _isVisible = false;
+            }
+        });
+        TriggerMessageQueueProcessing();
+    }
+
+    public bool IsVisible => _isVisible;
+
+    private void TriggerMessageQueueProcessing()
+    {
+        if (_hwnd != IntPtr.Zero && !_updatePending)
+        {
+            _updatePending = true;
+            LayeredWindowMethods.PostMessage(_hwnd, WM_PROCESS_QUEUE, IntPtr.Zero, IntPtr.Zero);
+        }
+    }
+
+    private void CleanupGdiResources()
+    {
+        if (_hOldBitmap != IntPtr.Zero && _hdcMem != IntPtr.Zero)
+        {
+            LayeredWindowMethods.SelectObject(_hdcMem, _hOldBitmap);
+            _hOldBitmap = IntPtr.Zero;
+        }
+        if (_hBitmap != IntPtr.Zero)
+        {
+            LayeredWindowMethods.DeleteObject(_hBitmap);
+            _hBitmap = IntPtr.Zero;
+        }
+        if (_hdcMem != IntPtr.Zero)
+        {
+            LayeredWindowMethods.DeleteDC(_hdcMem);
+            _hdcMem = IntPtr.Zero;
+        }
+        if (_hdcScreen != IntPtr.Zero)
+        {
+#pragma warning disable CA1806
+            User32Methods.ReleaseDC(IntPtr.Zero, _hdcScreen);
+#pragma warning restore CA1806
+            _hdcScreen = IntPtr.Zero;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+
+        _messageQueue.Add(() =>
+        {
+            if (_hwnd != IntPtr.Zero)
+            {
+                User32Methods.DestroyWindow(_hwnd);
+                _hwnd = IntPtr.Zero;
+            }
+            LayeredWindowMethods.PostQuitMessage(0);
+        });
+        TriggerMessageQueueProcessing();
+        _messageQueue.CompleteAdding();
+
+        _windowThread.Join(TimeSpan.FromSeconds(3));
+        _windowCreatedEvent.Dispose();
+        _messageQueue.Dispose();
+
+        _disposed = true;
+        _logger.LogDebug("[Issue #497] PhantomCursorWindow disposed");
+    }
+}

--- a/Baketa.Infrastructure.Platform/Windows/Overlay/PhantomCursorWindowAdapter.cs
+++ b/Baketa.Infrastructure.Platform/Windows/Overlay/PhantomCursorWindowAdapter.cs
@@ -1,0 +1,24 @@
+using System.Runtime.Versioning;
+using Baketa.Core.Abstractions.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Baketa.Infrastructure.Platform.Windows.Overlay;
+
+/// <summary>
+/// [Issue #497] PhantomCursorWindow を IPhantomCursorWindowAdapter として公開するアダプター
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class PhantomCursorWindowAdapter : IPhantomCursorWindowAdapter
+{
+    private readonly PhantomCursorWindow _window;
+
+    public PhantomCursorWindowAdapter(ILogger logger)
+    {
+        _window = new PhantomCursorWindow(logger);
+    }
+
+    public void UpdatePosition(int screenX, int screenY) => _window.UpdatePosition(screenX, screenY);
+    public void Show() => _window.Show();
+    public void Hide() => _window.Hide();
+    public void Dispose() => _window.Dispose();
+}

--- a/Baketa.Infrastructure.Platform/Windows/Services/CursorStateProvider.cs
+++ b/Baketa.Infrastructure.Platform/Windows/Services/CursorStateProvider.cs
@@ -1,0 +1,115 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Baketa.Core.Abstractions.Services;
+
+namespace Baketa.Infrastructure.Platform.Windows.Services;
+
+/// <summary>
+/// [Issue #497] Win32 APIによるカーソル状態プロバイダー
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class CursorStateProvider : ICursorStateProvider
+{
+    private const uint CURSOR_SHOWING = 0x00000001;
+    private readonly uint _ownProcessId = (uint)Environment.ProcessId;
+
+    public bool IsCursorHidden(out int screenX, out int screenY)
+    {
+        var state = GetCursorState();
+        screenX = state.ScreenX;
+        screenY = state.ScreenY;
+        return state.IsHidden;
+    }
+
+    public CursorState GetCursorState()
+    {
+        var cursorInfo = new CURSORINFO { cbSize = (uint)Marshal.SizeOf<CURSORINFO>() };
+        if (!GetCursorInfo(ref cursorInfo))
+            return default;
+
+        var isHidden = (cursorInfo.flags & CURSOR_SHOWING) == 0;
+        return new CursorState(
+            isHidden,
+            cursorInfo.ptScreenPos.X,
+            cursorInfo.ptScreenPos.Y,
+            cursorInfo.flags,
+            cursorInfo.hCursor);
+    }
+
+    public bool IsWindowForeground(nint windowHandle)
+    {
+        var foreground = GetForegroundWindow();
+
+        // 直接比較
+        if (foreground == windowHandle)
+            return true;
+
+        _ = GetWindowThreadProcessId(foreground, out var fgProcessId);
+        _ = GetWindowThreadProcessId(windowHandle, out var targetProcessId);
+
+        // ゲームの別ウィンドウ（親/子）がフォアグラウンドの場合
+        if (fgProcessId != 0 && fgProcessId == targetProcessId)
+            return true;
+
+        // Baketaオーバーレイがフォアグラウンドの場合も許可
+        // （通常の使用時はBaketaがゲームの上に表示されている）
+        return fgProcessId == _ownProcessId;
+    }
+
+    public bool IsPointInClientArea(nint windowHandle, int screenX, int screenY)
+    {
+        if (!GetClientRect(windowHandle, out var clientRect))
+            return false;
+
+        var pt = new POINT(screenX, screenY);
+        if (!ScreenToClient(windowHandle, ref pt))
+            return false;
+
+        return pt.X >= 0 && pt.X < clientRect.Right
+            && pt.Y >= 0 && pt.Y < clientRect.Bottom;
+    }
+
+    #region P/Invoke
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct CURSORINFO
+    {
+        public uint cbSize;
+        public uint flags;
+        public nint hCursor;
+        public POINT ptScreenPos;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X, Y;
+        public POINT(int x, int y) { X = x; Y = y; }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT
+    {
+        public int Left, Top, Right, Bottom;
+    }
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetCursorInfo(ref CURSORINFO pci);
+
+    [DllImport("user32.dll", SetLastError = false, ExactSpelling = true)]
+    private static extern nint GetForegroundWindow();
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetClientRect(nint hWnd, out RECT lpRect);
+
+    [DllImport("user32.dll", SetLastError = true, ExactSpelling = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool ScreenToClient(nint hWnd, ref POINT lpPoint);
+
+    [DllImport("user32.dll", SetLastError = false, ExactSpelling = true)]
+    private static extern uint GetWindowThreadProcessId(nint hWnd, out uint lpdwProcessId);
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- ゲームがシステムカーソルを非表示にしている場合に、半透明リング型の代替カーソルを表示する機能を実装
- Clean Architecture準拠: Core(インターフェース) → Platform(Win32実装) → Application(ビジネスロジック)
- フォアグラウンド判定を3段階に拡張（ゲーム直接/同一プロセス/Baketaオーバーレイ）

## 変更内容
| ファイル | 説明 |
|---------|------|
| `ICursorStateProvider.cs` | カーソル状態抽象化インターフェース（CursorState, CursorHiddenType） |
| `IPhantomCursorService.cs` | ファントムカーソルサービスインターフェース |
| `CursorStateProvider.cs` | Win32 API実装（GetCursorInfo, GetForegroundWindow等） |
| `PhantomCursorHostedService.cs` | 16msポーリング監視 + マウス静止検出 |
| `PhantomCursorWindow.cs` | LayeredWindow + GDI32半透明カーソル描画 |
| `PhantomCursorWindowAdapter.cs` | IPhantomCursorWindowAdapterアダプター |
| `ApplicationModule.cs` | DI登録（Singleton + HostedService） |
| `OverlayModule.cs` | ウィンドウファクトリ登録 |
| `PlatformModule.cs` | ICursorStateProvider登録 |

## 表示条件
1. システムカーソルが非表示（`CURSORINFO.flags`に`CURSOR_SHOWING`なし）
2. ゲームウィンドウ or Baketa自身がフォアグラウンド
3. マウスがゲームウィンドウのクライアント領域内

## Test plan
- [x] カーソル非表示ゲーム（TheComa2）でファントムカーソルが表示される
- [x] Baketaオーバーレイがフォアグラウンドでもカーソルが表示される
- [x] カーソル表示のゲームでは通常カーソルのまま（誤表示なし）
- [ ] ビルドエラーなし（0エラー、0警告）
- [ ] CI通過

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)