### PR TITLE
fix(#448): タイトルバー領域をOCR対象から除外

### DIFF
--- a/Baketa.Application/Services/Translation/CoordinateBasedTranslationService.cs
+++ b/Baketa.Application/Services/Translation/CoordinateBasedTranslationService.cs
@@ -439,7 +439,9 @@ public sealed class CoordinateBasedTranslationService : IDisposable, IEventProce
                 // 🔥 [Issue #193/#194] キャプチャ時に実行済みのOCR結果を伝達（二重OCR防止）
                 PreExecutedOcrResult = preExecutedOcrResult,
                 // [Issue #397] テキスト変化検知用の前回OCRテキスト
-                PreviousOcrText = previousOcrText
+                PreviousOcrText = previousOcrText,
+                // [Issue #448] タイトルバー除外用クライアント領域の正規化座標
+                ClientAreaBounds = CalculateClientAreaBounds(windowHandle)
             };
 
             // パイプライン実行（ImageChangeDetection → OcrExecution）
@@ -2110,6 +2112,50 @@ public sealed class CoordinateBasedTranslationService : IDisposable, IEventProce
         }
 
         return Size.Empty;
+    }
+
+    /// <summary>
+    /// [Issue #448] クライアント領域の正規化座標を計算（タイトルバー除外用）
+    /// ウィンドウモード時にタイトルバー・ウィンドウ枠をOCR対象から除外するため、
+    /// クライアント領域を0.0-1.0の正規化座標で返す。
+    /// 全画面/ボーダレスの場合はnullを返す（画像全体がOCR対象）。
+    /// </summary>
+    private NormalizedRect? CalculateClientAreaBounds(IntPtr hwnd)
+    {
+        if (hwnd == IntPtr.Zero || _windowManager is null)
+            return null;
+
+        var windowBounds = _windowManager.GetWindowBounds(hwnd);
+        var clientBounds = _windowManager.GetClientBounds(hwnd);
+
+        if (windowBounds is null || clientBounds is null)
+            return null;
+
+        var winW = windowBounds.Value.Width;
+        var winH = windowBounds.Value.Height;
+        var clientW = clientBounds.Value.Width;
+        var clientH = clientBounds.Value.Height;
+
+        if (winW <= 0 || winH <= 0 || clientW <= 0 || clientH <= 0)
+            return null;
+
+        // ウィンドウサイズとクライアントサイズがほぼ同じ → 全画面/ボーダレス
+        if (winH - clientH <= 2 && winW - clientW <= 2)
+            return null;
+
+        // ボーダー幅の推定（左右対称を仮定、数px程度なのでOCR精度に影響なし）
+        var leftBorder = (winW - clientW) / 2;
+        var bottomBorder = leftBorder;
+        var titleBarHeight = winH - clientH - bottomBorder;
+
+        if (titleBarHeight <= 0)
+            return null;
+
+        return new NormalizedRect(
+            (float)leftBorder / winW,
+            (float)(titleBarHeight + leftBorder) / winH,
+            (float)clientW / winW,
+            (float)clientH / winH);
     }
 
     #endregion

--- a/Baketa.Core/Models/Processing/ProcessingModels.cs
+++ b/Baketa.Core/Models/Processing/ProcessingModels.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Drawing;
 using Baketa.Core.Abstractions.Imaging;
+using Baketa.Core.Models.Roi;
 
 namespace Baketa.Core.Models.Processing;
 
@@ -97,6 +98,13 @@ public sealed record ProcessingPipelineInput : IDisposable
     /// Size.Empty の場合はスケーリングをスキップする。
     /// </remarks>
     public Size OriginalWindowSize { get; init; } = Size.Empty;
+
+    /// <summary>
+    /// [Issue #448] クライアント領域の正規化座標 (0.0-1.0)
+    /// タイトルバー・ウィンドウ枠を除外したOCR対象領域を示す。
+    /// null の場合、画像全体がOCR対象（全画面/ボーダレス時）。
+    /// </summary>
+    public NormalizedRect? ClientAreaBounds { get; init; }
 
     /// <summary>
     /// 🎯 UltraThink: 所有権管理フラグ

--- a/Baketa.Infrastructure.Platform/DI/Modules/PlatformModule.cs
+++ b/Baketa.Infrastructure.Platform/DI/Modules/PlatformModule.cs
@@ -77,8 +77,12 @@ public class PlatformModule : ServiceModuleBase
             Baketa.Infrastructure.Platform.Windows.Capture.GdiScreenCapturer>();
 
         // ウィンドウマネージャー
-        services.AddSingleton<Baketa.Core.Abstractions.Platform.Windows.IWindowManager,
-            Baketa.Infrastructure.Platform.Windows.WindowsManager>();
+        services.AddSingleton<Baketa.Infrastructure.Platform.Windows.WindowsManager>();
+        services.AddSingleton<Baketa.Core.Abstractions.Platform.Windows.IWindowManager>(
+            sp => sp.GetRequiredService<Baketa.Infrastructure.Platform.Windows.WindowsManager>());
+        // [Issue #448] CoordinateBasedTranslationServiceが使用するPlatform.IWindowManagerも同一インスタンスで登録
+        services.AddSingleton<Baketa.Core.Abstractions.Platform.IWindowManager>(
+            sp => sp.GetRequiredService<Baketa.Infrastructure.Platform.Windows.WindowsManager>());
 
         // 画像ファクトリー（Phase 3.1: SafeImage統合対応）
         services.AddSingleton<Baketa.Core.Abstractions.Factories.IWindowsImageFactory,

--- a/Baketa.Infrastructure.Platform/Windows/WindowsManager.cs
+++ b/Baketa.Infrastructure.Platform/Windows/WindowsManager.cs
@@ -17,7 +17,7 @@ namespace Baketa.Infrastructure.Platform.Windows;
 /// IWindowManagerインターフェースのWindows特化実装
 /// Win32 APIを使用して実際のウィンドウ情報を取得
 /// </summary>
-public class WindowsManager : IWindowManager
+public class WindowsManager : IWindowManager, Baketa.Core.Abstractions.Platform.IWindowManager
 {
     // P/Invoke宣言は NativeMethods.User32Methods を使用
 
@@ -157,8 +157,18 @@ public class WindowsManager : IWindowManager
     /// <returns>クライアント領域の位置とサイズを表す Rectangle</returns>
     public Rectangle? GetClientBounds(IntPtr handle)
     {
-        // スタブ実装では780x560の位置(10,30)の矩形を返す（ウィンドウ境界と想定）
-        return new Rectangle(10, 30, 780, 560);
+        try
+        {
+            if (NativeMethods.User32Methods.GetClientRect(handle, out NativeMethods.RECT clientRect))
+            {
+                return new Rectangle(0, 0, clientRect.right - clientRect.left, clientRect.bottom - clientRect.top);
+            }
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/Baketa.Infrastructure/Processing/Strategies/OcrExecutionStageStrategy.cs
+++ b/Baketa.Infrastructure/Processing/Strategies/OcrExecutionStageStrategy.cs
@@ -315,6 +315,17 @@ public class OcrExecutionStageStrategy : IProcessingStageStrategy, IDisposable
                         partialOcrCount + 1, InitialExpansionCycleLimit, AdjacentHorizontalRange, AdjacentVerticalRange);
                 }
 
+                // [Issue #448] クライアント領域制約の適用（タイトルバー除外）
+                if (context.Input.ClientAreaBounds is { } clientArea1)
+                {
+                    combinedRegions = ApplyClientAreaConstraint(combinedRegions, ocrImage.Width, ocrImage.Height, clientArea1);
+                    if (combinedRegions.Count == 0)
+                    {
+                        _logger.LogDebug("[Issue #448] クライアント領域制約により全領域が除外されました（学習済みROIパス）");
+                        return ProcessingStageResult.CreateSkipped(StageType, "All regions outside client area");
+                    }
+                }
+
                 _logger.LogInformation("🎯 [Issue #293 Phase 7.3] 学習済みROI + 変化領域併用OCR: 学習済み{LearnedCount}領域 + 変化{ChangedCount}領域 = 合計{TotalCount}領域",
                     learnedRegions.Count, combinedRegions.Count - learnedRegions.Count, combinedRegions.Count);
 
@@ -334,8 +345,35 @@ public class OcrExecutionStageStrategy : IProcessingStageStrategy, IDisposable
                         partialOcrCount + 1, InitialExpansionCycleLimit, AdjacentHorizontalRange, AdjacentVerticalRange);
                 }
 
+                // [Issue #448] クライアント領域制約の適用（タイトルバー除外）
+                if (context.Input.ClientAreaBounds is { } clientArea2)
+                {
+                    mergedRegions = ApplyClientAreaConstraint(mergedRegions, ocrImage.Width, ocrImage.Height, clientArea2);
+                    if (mergedRegions.Count == 0)
+                    {
+                        _logger.LogDebug("[Issue #448] クライアント領域制約により全領域が除外されました（変化領域パス）");
+                        return ProcessingStageResult.CreateSkipped(StageType, "All regions outside client area");
+                    }
+                }
+
                 _logger.LogInformation("🎯 [Issue #293] 変化領域ベース部分OCR実行: {RegionCount}結合領域を処理（探索モード）", mergedRegions.Count);
                 return await ExecutePartialOcrAsync(context, mergedRegions, ocrImage, stopwatch, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            // [Issue #448] 全画面OCRパス: クライアント領域制約がある場合は部分OCRにリダイレクト
+            if (context.Input.ClientAreaBounds is { } clientArea3)
+            {
+                var clientRect = new Rectangle(
+                    (int)(clientArea3.X * ocrImage.Width),
+                    (int)(clientArea3.Y * ocrImage.Height),
+                    (int)(clientArea3.Width * ocrImage.Width),
+                    (int)(clientArea3.Height * ocrImage.Height));
+
+                _logger.LogInformation("[Issue #448] タイトルバー除外: 全画面OCR→クライアント領域部分OCR ({X},{Y},{W}x{H})",
+                    clientRect.X, clientRect.Y, clientRect.Width, clientRect.Height);
+
+                return await ExecutePartialOcrAsync(context, [clientRect], ocrImage, stopwatch, cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -1146,6 +1184,26 @@ public class OcrExecutionStageStrategy : IProcessingStageStrategy, IDisposable
         }
 
         return expandedRegions;
+    }
+
+    /// <summary>
+    /// [Issue #448] クライアント領域制約の適用（タイトルバー除外）
+    /// 各OCR対象領域をクライアント領域と交差させ、タイトルバー・ウィンドウ枠内の領域を除外する。
+    /// 交差結果が小さすぎる（10x10未満）領域もフィルタする。
+    /// </summary>
+    internal static List<Rectangle> ApplyClientAreaConstraint(
+        List<Rectangle> regions, int imageWidth, int imageHeight, NormalizedRect clientArea)
+    {
+        var clientRect = new Rectangle(
+            (int)(clientArea.X * imageWidth),
+            (int)(clientArea.Y * imageHeight),
+            (int)(clientArea.Width * imageWidth),
+            (int)(clientArea.Height * imageHeight));
+
+        return regions
+            .Select(r => Rectangle.Intersect(r, clientRect))
+            .Where(r => !r.IsEmpty && r.Width > 10 && r.Height > 10)
+            .ToList();
     }
 
     /// <summary>

--- a/tests/Baketa.Infrastructure.Tests/Processing/Strategies/OcrExecutionStageStrategyClientAreaTests.cs
+++ b/tests/Baketa.Infrastructure.Tests/Processing/Strategies/OcrExecutionStageStrategyClientAreaTests.cs
@@ -1,0 +1,130 @@
+using System.Drawing;
+using Baketa.Core.Models.Roi;
+using Baketa.Infrastructure.Processing.Strategies;
+using Xunit;
+
+namespace Baketa.Infrastructure.Tests.Processing.Strategies;
+
+/// <summary>
+/// [Issue #448] ApplyClientAreaConstraint メソッドの単体テスト
+/// タイトルバー領域をOCR対象から除外するクライアント領域制約のテスト
+/// </summary>
+public class OcrExecutionStageStrategyClientAreaTests
+{
+    private const int ImageWidth = 1000;
+    private const int ImageHeight = 800;
+
+    // クライアント領域: タイトルバー40px、左右ボーダー各10px、下ボーダー10px
+    // → ClientArea: X=10/1000=0.01, Y=40/800=0.05, W=980/1000=0.98, H=750/800=0.9375
+    private static readonly NormalizedRect TestClientArea = new(0.01f, 0.05f, 0.98f, 0.9375f);
+
+    [Fact]
+    public void ApplyClientAreaConstraint_RegionInsideClientArea_ReturnsUnchanged()
+    {
+        // Arrange: クライアント領域内に完全に収まる領域
+        var regions = new List<Rectangle>
+        {
+            new(100, 100, 200, 150)
+        };
+
+        // Act
+        var result = OcrExecutionStageStrategy.ApplyClientAreaConstraint(
+            regions, ImageWidth, ImageHeight, TestClientArea);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(new Rectangle(100, 100, 200, 150), result[0]);
+    }
+
+    [Fact]
+    public void ApplyClientAreaConstraint_RegionOverlapsTitleBar_IsTrimmed()
+    {
+        // Arrange: タイトルバー領域(Y=0-40)と重なる領域
+        var regions = new List<Rectangle>
+        {
+            new(100, 10, 200, 100)  // Y=10からY=110まで
+        };
+
+        // Act
+        var result = OcrExecutionStageStrategy.ApplyClientAreaConstraint(
+            regions, ImageWidth, ImageHeight, TestClientArea);
+
+        // Assert: Y=40(クライアント領域開始)で切り詰められる
+        Assert.Single(result);
+        var trimmed = result[0];
+        Assert.Equal(100, trimmed.X);
+        Assert.Equal(40, trimmed.Y);  // タイトルバー下端から開始
+        Assert.True(trimmed.Height < 100);  // 元より小さくなる
+    }
+
+    [Fact]
+    public void ApplyClientAreaConstraint_RegionEntirelyInTitleBar_IsExcluded()
+    {
+        // Arrange: 完全にタイトルバー内の領域
+        var regions = new List<Rectangle>
+        {
+            new(100, 5, 200, 30)  // Y=5からY=35まで（タイトルバー内）
+        };
+
+        // Act
+        var result = OcrExecutionStageStrategy.ApplyClientAreaConstraint(
+            regions, ImageWidth, ImageHeight, TestClientArea);
+
+        // Assert: 完全に除外される
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ApplyClientAreaConstraint_SmallIntersection_IsExcluded()
+    {
+        // Arrange: 交差結果が小さすぎる（10x10未満）領域
+        var regions = new List<Rectangle>
+        {
+            new(100, 35, 8, 50)  // 幅8px → Intersect後もwidth<=10でフィルタされる
+        };
+
+        // Act
+        var result = OcrExecutionStageStrategy.ApplyClientAreaConstraint(
+            regions, ImageWidth, ImageHeight, TestClientArea);
+
+        // Assert: 小さすぎる交差結果は除外
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ApplyClientAreaConstraint_MultipleRegions_FiltersCorrectly()
+    {
+        // Arrange: 複数領域（クライアント内、タイトルバー内、重なり）
+        var regions = new List<Rectangle>
+        {
+            new(100, 200, 200, 150),  // クライアント内 → 残る
+            new(100, 5, 200, 20),     // タイトルバー内 → 除外
+            new(100, 20, 200, 100),   // タイトルバーと重なり → トリミング
+        };
+
+        // Act
+        var result = OcrExecutionStageStrategy.ApplyClientAreaConstraint(
+            regions, ImageWidth, ImageHeight, TestClientArea);
+
+        // Assert: タイトルバー内の領域のみ除外
+        Assert.Equal(2, result.Count);
+        // 1つ目はそのまま
+        Assert.Equal(new Rectangle(100, 200, 200, 150), result[0]);
+        // 2つ目はトリミングされている
+        Assert.True(result[1].Y >= 40);
+    }
+
+    [Fact]
+    public void ApplyClientAreaConstraint_EmptyRegionList_ReturnsEmpty()
+    {
+        // Arrange
+        var regions = new List<Rectangle>();
+
+        // Act
+        var result = OcrExecutionStageStrategy.ApplyClientAreaConstraint(
+            regions, ImageWidth, ImageHeight, TestClientArea);
+
+        // Assert
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
## Summary

- ウィンドウモードのゲームキャプチャ時、タイトルバーのテキスト（例: `StellarCode - v1.3`）がOCR検出される問題を修正
- 画像クロップではなくOCR対象領域をクライアント領域に制限する方式を採用（座標系統一を維持、#449互換）
- `GetClientRect` Win32 APIでクライアント領域サイズを取得し、ウィンドウサイズとの差分からタイトルバー高さを推定して正規化座標に変換

## Changes (6 files)

| ファイル | 変更内容 |
|---------|---------|
| `WindowsManager.cs` | `GetClientBounds` stub→Win32 API実装 + `Platform.IWindowManager`実装追加 |
| `PlatformModule.cs` | `Platform.IWindowManager`のDI登録追加（同一インスタンス共有） |
| `ProcessingModels.cs` | `ProcessingPipelineInput`に`ClientAreaBounds`プロパティ追加 |
| `CoordinateBasedTranslationService.cs` | `CalculateClientAreaBounds()`追加 |
| `OcrExecutionStageStrategy.cs` | `ApplyClientAreaConstraint()`追加、3 OCRパス全てに適用 |
| `OcrExecutionStageStrategyClientAreaTests.cs` | 単体テスト6件（新規） |

## Test plan

- [x] ウィンドウモード: タイトルバーテキストがOCR検出されないこと確認済み
- [x] 全画面モード: `ClientAreaBounds=null`で従来通り全画面OCR確認済み
- [x] 単体テスト6件全て成功
- [x] ビルド: 0エラー0警告
- [ ] 最大化ウィンドウでの動作確認
- [ ] DPIスケーリング環境での動作確認

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)