### PR TITLE
feat(#541): NLLB-200 ONNX推論に繰り返しペナルティを導入

### DIFF
--- a/Baketa.Infrastructure/Translation/Onnx/OnnxTranslationEngine.cs
+++ b/Baketa.Infrastructure/Translation/Onnx/OnnxTranslationEngine.cs
@@ -255,10 +255,20 @@ public sealed class OnnxTranslationEngine : TranslationEngineBase, IUnloadableTr
         }
     }
 
+    // [Issue #541] デコーディングパラメータ
+    private const float DefaultRepetitionPenalty = 1.2f;
+    private const int DefaultNoRepeatNgramSize = 3;
+
     /// <summary>
     /// グリーディサーチによる seq2seq 推論
+    /// [Issue #541] 繰り返しペナルティ対応
     /// </summary>
-    private int[] RunGreedySearch(int[] inputIds, int targetLangTokenId, int maxLength = 128)
+    private int[] RunGreedySearch(
+        int[] inputIds,
+        int targetLangTokenId,
+        int maxLength = 128,
+        float repetitionPenalty = DefaultRepetitionPenalty,
+        int noRepeatNgramSize = DefaultNoRepeatNgramSize)
     {
         var batchSize = 1;
         var seqLen = inputIds.Length;
@@ -375,14 +385,56 @@ public sealed class OnnxTranslationEngine : TranslationEngineBase, IUnloadableTr
                 var vocabSize = logits.Dimensions[^1];
                 var lastPos = logits.Dimensions[1] - 1;
 
+                // [Issue #541] logitsをfloat配列にコピー（ペナルティ適用用）
+                var logitScores = new float[vocabSize];
+                for (int v = 0; v < vocabSize; v++)
+                    logitScores[v] = logits[0, lastPos, v];
+
+                // [Issue #541] 繰り返しペナルティ: 既に生成されたトークンのスコアを減衰
+                if (repetitionPenalty > 1.0f)
+                {
+                    foreach (var prevId in generatedIds)
+                    {
+                        if (prevId < 0 || prevId >= vocabSize) continue;
+                        if (logitScores[prevId] > 0)
+                            logitScores[prevId] /= repetitionPenalty;
+                        else
+                            logitScores[prevId] *= repetitionPenalty;
+                    }
+                }
+
+                // [Issue #541] N-gram繰り返しブロック: 直近のN-1トークンと同じN-gramを禁止
+                if (noRepeatNgramSize > 0 && generatedIds.Count >= noRepeatNgramSize)
+                {
+                    var ngramPrefix = generatedIds.Skip(generatedIds.Count - (noRepeatNgramSize - 1)).ToArray();
+                    // 過去の全位置でngramPrefixに続いたトークンを収集
+                    for (int i = 0; i <= generatedIds.Count - noRepeatNgramSize; i++)
+                    {
+                        bool match = true;
+                        for (int j = 0; j < noRepeatNgramSize - 1; j++)
+                        {
+                            if (generatedIds[i + j] != ngramPrefix[j])
+                            {
+                                match = false;
+                                break;
+                            }
+                        }
+                        if (match)
+                        {
+                            var bannedId = generatedIds[i + noRepeatNgramSize - 1];
+                            if (bannedId >= 0 && bannedId < vocabSize)
+                                logitScores[bannedId] = float.NegativeInfinity;
+                        }
+                    }
+                }
+
                 int bestId = 0;
                 float bestScore = float.MinValue;
                 for (int v = 0; v < vocabSize; v++)
                 {
-                    var score = logits[0, lastPos, v];
-                    if (score > bestScore)
+                    if (logitScores[v] > bestScore)
                     {
-                        bestScore = score;
+                        bestScore = logitScores[v];
                         bestId = v;
                     }
                 }


### PR DESCRIPTION
## Summary

- NLLB-200 ONNX推論のグリーディデコーディングに繰り返しペナルティを導入
- 短い入力や曖昧な入力での繰り返しループ・ハルシネーションを予防
- 既存のFallbackOrchestratorのハルシネーション事後検出と併せて二重防御

## Changes

`OnnxTranslationEngine.cs` の `RunGreedySearch` メソッドに2段階のペナルティを追加:

1. **Repetition Penalty (デフォルト: 1.2)**: 既に生成されたトークンのlogitスコアを減衰させ、同一トークンの繰り返し確率を下げる
2. **No-Repeat N-gram (デフォルト: 3-gram)**: 過去に出現した3-gramと同じパターンの繰り返しを完全にブロック（logitを-∞に設定）

## 動作確認

- 複数のゲームテキストでローカル翻訳を実行し、繰り返しループが発生しないことを確認
- 短文入力（`GAME`等）でもハルシネーションなく正常翻訳
- 処理時間への影響: 無視できるレベル（122ms〜671ms、従来と同等）
- 既存テスト33件全て成功

## Test plan

- [x] ローカル翻訳の正常動作確認（回帰なし）
- [x] 短文入力での繰り返し抑制確認
- [x] 既存テスト33件パス
- [x] ビルド: 0エラー0警告

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)