### PR TITLE
fix(#546): 起動時のアップデートチェック重複実行を修正

### DIFF
--- a/Baketa.UI/App.axaml.cs
+++ b/Baketa.UI/App.axaml.cs
@@ -926,22 +926,12 @@ internal sealed partial class App : Avalonia.Application, IDisposable
     {
         try
         {
-            // [Issue #511] 早期チェックで既に初期化済みの場合
+            // [Issue #511] 早期チェックで既に初期化済みの場合はスキップ
+            // [Issue #546] 早期チェック（CheckForUpdatesEarlyAsync）で既にAppCastを取得済みのため、
+            // 再度のバックグラウンドチェックは不要（重複リクエスト防止）
             if (_updateService != null)
             {
-                _logger?.LogInformation("[Issue #511] UpdateService既に初期化済み - バックグラウンドチェックのみ");
-                _ = Task.Run(async () =>
-                {
-                    try
-                    {
-                        await Task.Delay(5000).ConfigureAwait(false);
-                        await _updateService.CheckForUpdatesInBackgroundAsync().ConfigureAwait(false);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger?.LogWarning(ex, "[Issue #249] サイレント更新チェック失敗（継続）");
-                    }
-                });
+                _logger?.LogInformation("[Issue #546] UpdateService既に初期化済み - 重複チェックをスキップ");
                 return;
             }
 


### PR DESCRIPTION
## Summary

- 起動時にAppCastダウンロードが2回実行されていた問題を修正
- 早期チェック（Issue #511）完了後の`InitializeUpdateServiceAsync`で、バックグラウンドチェックをスキップ

## Changes

`App.axaml.cs`: 早期チェック済み（`_updateService != null`）の場合、5秒後のバックグラウンドチェック（`CheckForUpdatesInBackgroundAsync`）を実行せず即座にreturn。フォールバックパス（早期チェック未実行時）は維持。

## Test plan

- [x] 起動ログでAppCastダウンロードが1回のみ確認
- [x] `[Issue #546] UpdateService既に初期化済み - 重複チェックをスキップ` ログ出力確認
- [x] ビルド: 0エラー

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)